### PR TITLE
chore: add release workflow, PR template, and release docs

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,20 @@
+## What
+
+<!-- Brief description of what this PR does -->
+
+## Why
+
+<!-- Why is this change needed? Link to issue if applicable -->
+
+Closes #<!-- issue number -->
+
+## How
+
+<!-- How does this work? Any notable implementation details? -->
+
+## Checklist
+
+- [ ] Tests pass (`npm test`)
+- [ ] CHANGELOG.md updated (if user-visible change)
+- [ ] No new runtime dependencies added
+- [ ] Documentation updated (if applicable)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,63 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        node-version: [18, 20, 22]
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: ${{ matrix.node-version }}
+      - run: npm test
+
+  release:
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Extract version from tag
+        id: version
+        run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+
+      - name: Validate version matches package.json
+        run: |
+          PKG_VERSION=$(node -p "require('./package.json').version")
+          TAG_VERSION="${{ steps.version.outputs.version }}"
+          if [ "$PKG_VERSION" != "$TAG_VERSION" ]; then
+            echo "::error::Tag version ($TAG_VERSION) does not match package.json ($PKG_VERSION)"
+            exit 1
+          fi
+
+      - name: Extract changelog for this version
+        id: changelog
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          # Extract the section for this version from CHANGELOG.md
+          awk "/^## \[${VERSION}\]/{found=1; next} /^## \[/{if(found) exit} found" CHANGELOG.md > release_notes.md
+          if [ ! -s release_notes.md ]; then
+            echo "No changelog entry found for version $VERSION" > release_notes.md
+          fi
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          body_path: release_notes.md
+          draft: false
+          prerelease: ${{ contains(github.ref_name, '-') }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Added
+
+- **Release workflow** — automated GitHub Releases from version tags (`release.yml`)
+- **PR template** — standardized pull request format
+- **Release process docs** — versioning and release steps in CONTRIBUTING.md
+
 ## [1.0.0] — 2025-04-14
 
 Complete rewrite with modular architecture, comprehensive testing, and cross-platform support.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -88,6 +88,40 @@ These are intentional constraints — please don't change them without discussio
 - All tests must pass (`npm test`)
 - Update CHANGELOG.md for user-visible changes
 - No new runtime dependencies
+- Direct pushes to `main` are blocked — all changes go through PRs
+
+## Release Process
+
+This project uses [Semantic Versioning](https://semver.org/) and automated GitHub Releases.
+
+### To release a new version:
+
+1. **Create a PR** with your changes:
+   - Update `version` in `package.json`
+   - Add a new section to `CHANGELOG.md` under `## [x.y.z] — YYYY-MM-DD`
+   - Follow [Keep a Changelog](https://keepachangelog.com/) format
+
+2. **Merge the PR** — CI runs tests across 3 OSes × 3 Node versions
+
+3. **Tag and push** (from an up-to-date `main`):
+   ```bash
+   git tag v1.2.0
+   git push origin v1.2.0
+   ```
+
+4. **Automated release** — the `release.yml` workflow:
+   - Runs the full test matrix
+   - Validates the tag version matches `package.json`
+   - Extracts release notes from `CHANGELOG.md`
+   - Creates a GitHub Release
+
+### Version bump guidelines
+
+| Change type | Version bump | Example |
+|-------------|-------------|---------|
+| Bug fixes, docs, polish | Patch (`1.0.x`) | Fix install.sh quoting |
+| New features, backward-compatible | Minor (`1.x.0`) | Add date range filtering |
+| Breaking changes | Major (`x.0.0`) | Change storage format |
 
 ## Reporting Issues
 


### PR DESCRIPTION
## What

Add release infrastructure to enable proper PR-based workflow and automated releases.

## Why

Transitioning from admin-bypass direct pushes to standard PR-based workflow. This is the foundation for all future changes.

## How

- **release.yml**: Automated GitHub Release on tag push (runs full test matrix first, validates version, extracts changelog)
- **PR template**: Standardized checklist for all PRs
- **CONTRIBUTING.md**: Added release process section with version bump guidelines
- **CHANGELOG.md**: Added [Unreleased] section per Keep a Changelog convention

## Checklist

- [x] Tests pass (no code changes, CI will verify)
- [x] CHANGELOG.md updated
- [x] No new runtime dependencies added
- [x] Documentation updated