### PR TITLE
chore: bump to v1.0.1 for npm republish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+## [1.0.1] — 2025-04-21
+
+### Fixed
+
+- **npm metadata** — repository URL now correctly points to `microsoft/copilot-brag-sheet`
+
 ### Added
 
 - **Release workflow** — automated GitHub Releases from version tags (`release.yml`)
@@ -14,14 +20,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ### Changed
 
-- **Skill v1.1** — major SKILL.md enhancement based on multi-model analysis:
+- **Skill v1.1** — major SKILL.md enhancement:
   - Expanded frontmatter description with 25+ trigger phrases
-  - Quick Start table for instant mode selection
-  - Agent Behavior Rules (10 DOs/DON'Ts)
-  - Anti-Patterns table (8 common mistakes)
-  - Evidence Ladder (ranked evidence types)
-  - Output Contract (7 quality guarantees)
-  - Gotchas section (6 edge cases)
+  - Quick Start table, Agent Behavior Rules, Anti-Patterns table
+  - Evidence Ladder, Output Contract, Gotchas section
   - Executable backfill commands (git log, gh pr list)
 
 ## [1.0.0] — 2025-04-14

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "copilot-brag-sheet",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Auto-track AI coding sessions into a structured work log. Zero dependencies, local-first.",
   "type": "module",
   "main": "extension.mjs",
@@ -10,10 +10,34 @@
   "scripts": {
     "test": "node --test"
   },
-  "keywords": ["copilot", "cli", "extension", "brag-sheet", "work-tracker", "developer-tools", "performance-review", "ai-tools", "local-first", "github-copilot"],
+  "keywords": [
+    "copilot",
+    "cli",
+    "extension",
+    "brag-sheet",
+    "work-tracker",
+    "developer-tools",
+    "performance-review",
+    "ai-tools",
+    "local-first",
+    "github-copilot"
+  ],
   "author": "Microsoft",
   "license": "MIT",
-  "repository": { "type": "git", "url": "https://github.com/microsoft/copilot-brag-sheet" },
-  "engines": { "node": ">=18.0.0" },
-  "files": ["extension.mjs", "lib/", "bin/", "plugin.json", "package.json", "README.md", "LICENSE"]
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/microsoft/copilot-brag-sheet"
+  },
+  "engines": {
+    "node": ">=18.0.0"
+  },
+  "files": [
+    "extension.mjs",
+    "lib/",
+    "bin/",
+    "plugin.json",
+    "package.json",
+    "README.md",
+    "LICENSE"
+  ]
 }


### PR DESCRIPTION
## What
Patch bump to v1.0.1 so npm shows correct repository URL (microsoft/ instead of vidhartbhatia/).

## Why
npm won't let us update metadata without a version bump. Current npm listing points to the old personal repo.

## How
- Bump version in package.json: 1.0.0 → 1.0.1
- Move [Unreleased] changes into [1.0.1] changelog entry

## After merge
Tag \1.0.1\ → release.yml creates GitHub Release → then \
pm publish\ from local.

## Checklist
- [x] Tests pass (no code changes)
- [x] CHANGELOG.md updated
- [x] No new runtime dependencies added