### PR TITLE
fix: use shields.io for CI badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 A [**brag sheet**](https://jvns.ca/blog/brag-documents/) is a running record of your accomplishments — so when review season arrives, you have receipts, not a blank page. This extension builds yours automatically.
 
-[![CI](https://github.com/microsoft/copilot-brag-sheet/actions/workflows/ci.yml/badge.svg)](https://github.com/microsoft/copilot-brag-sheet/actions/workflows/ci.yml)
+[![CI](https://img.shields.io/github/actions/workflow/status/microsoft/copilot-brag-sheet/ci.yml?branch=main&label=CI)](https://github.com/microsoft/copilot-brag-sheet/actions/workflows/ci.yml)
 [![npm version](https://img.shields.io/npm/v/copilot-brag-sheet.svg)](https://www.npmjs.com/package/copilot-brag-sheet)
 [![npm downloads](https://img.shields.io/npm/dm/copilot-brag-sheet.svg)](https://www.npmjs.com/package/copilot-brag-sheet)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)


### PR DESCRIPTION
## What
Switch CI badge from GitHub native badge.svg to shields.io.

## Why
GitHub's native badge has persistent caching/CSP issues causing broken image on the README.

## Checklist
- [x] Tests pass (no code changes)
- [x] No new runtime dependencies