### PR TITLE
ci: auto-publish to npm on tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: write
+  id-token: write  # required for npm provenance attestation
 
 jobs:
   test:
@@ -29,6 +30,11 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 20
+          registry-url: 'https://registry.npmjs.org/'
 
       - name: Extract version from tag
         id: version
@@ -61,3 +67,10 @@ jobs:
           prerelease: ${{ contains(github.ref_name, '-') }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Publish to npm
+        # Skip pre-release tags (e.g. v1.0.0-rc1) so we can experiment without polluting the registry
+        if: ${{ !contains(github.ref_name, '-') }}
+        run: npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Adds npm publish step to release.yml using the new NPM_TOKEN repo secret. Future `git push origin v*` tags will publish to npm automatically (no more manual `npm publish`). Uses `--provenance` for cryptographic attestation linking the package to this CI run.