### PR TITLE
v1.0.3: install bug fixes + README rewrite + ROADMAP refocus

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,6 +49,53 @@ jobs:
             exit 1
           fi
 
+      - name: Validate tarball contents
+        run: |
+          # Required files that must be in the published tarball.
+          # If we add a new lib/foo.mjs and forget to update package.json's "files"
+          # whitelist, this catches it before the broken publish goes out.
+          REQUIRED=(
+            extension.mjs
+            plugin.json
+            package.json
+            bin/install.mjs
+            bin/setup.mjs
+            lib/config.mjs
+            lib/git-backup.mjs
+            lib/lock.mjs
+            lib/paths.mjs
+            lib/records.mjs
+            lib/render.mjs
+            lib/storage.mjs
+          )
+          npm pack --dry-run --json > /tmp/pack.json
+          node -e "
+            const required = process.env.REQUIRED.split('\n').filter(Boolean);
+            const pack = JSON.parse(require('fs').readFileSync('/tmp/pack.json', 'utf8'));
+            const got = new Set(pack[0].files.map(f => f.path));
+            const missing = required.filter(f => !got.has(f));
+            if (missing.length) {
+              console.error('::error::Missing in tarball:');
+              missing.forEach(f => console.error('  - ' + f));
+              process.exit(1);
+            }
+            console.log('Tarball contains all', required.length, 'required files.');
+          "
+        env:
+          REQUIRED: |
+            extension.mjs
+            plugin.json
+            package.json
+            bin/install.mjs
+            bin/setup.mjs
+            lib/config.mjs
+            lib/git-backup.mjs
+            lib/lock.mjs
+            lib/paths.mjs
+            lib/records.mjs
+            lib/render.mjs
+            lib/storage.mjs
+
       - name: Extract changelog for this version
         id: changelog
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,32 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+## [1.0.3] — 2026-05-01
+
+### Fixed
+
+- **`plugin.json` version drift** — was hardcoded to `1.0.0` while `package.json` had moved to `1.0.2`. Removed the duplicate `version` field; `package.json` is now the single source of truth.
+- **`bin/setup.mjs` non-TTY hang** — calling the wizard headless (CI, Docker, `< /dev/null`) used to block forever on the first prompt. Now exits cleanly with code 2 and a helpful message pointing at `config.json`.
+- **README curl one-liner** — replaced `curl -sL` with `curl -fsSL` so HTTP errors fail loudly instead of piping HTML into bash.
+
+### Added
+
+- **`@github/copilot` declared as optional `peerDependency`** — extension imports `@github/copilot-sdk/extension` which the Copilot CLI host injects at load time. Declaring it (with `optional: true`) gives static-analysis tools and `depcheck` a hook without forcing install on end users.
+- **`copilot-brag-sheet-setup` bin** is now the recommended way to re-run the wizard (no more remembering the absolute path).
+- **`COPILOT_HOME` documented** in the README's Environment Variables section.
+- **`BRAG_SHEET_DEBUG=1` env var** — when set, `extension.mjs` logs to stderr at module load and `onSessionStart` so you can verify the host actually loaded the extension.
+- **README rewrite** — based on competitive analysis (claudskills.com is reposting our SKILL.md without attribution):
+  - Stronger hero hook ("Turn vague *what did I do?* into evidence-backed impact statements")
+  - New "**Why an extension, not just a SKILL.md?**" section that names the moat: deterministic capture, structured storage, typed tool contracts
+  - "**When the agent will use this**" section listing the trigger phrases
+- **CI: tarball validation** — `release.yml` now checks `npm pack --dry-run` against a required-files list before publishing. Catches future cases where a new `lib/foo.mjs` gets added but isn't in `package.json`'s `files` whitelist.
+- **`prepublishOnly` script** — runs `npm test` automatically on local `npm publish` to prevent accidental untested releases.
+
+### Changed
+
+- **ROADMAP.md restructured** — Priority 0 is now distribution + product moat (summary inference, blog post, SEO landing page, attribution reclaim) based on real traffic data (218 unique visitors / 53 cloners in 14 days from awesome-copilot). Cross-engine moved to Priority 1. Packaging polish moved to Priority 2.
+- **Removed dead code** in `bin/install.mjs` (`SKIP` set defined but never used; `pathToFileURL` imported then voided).
+
 ## [1.0.2] — 2026-05-01
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Copilot Brag Sheet
 
-> Never lose track of what you shipped — auto-log every AI coding session.
+> **Turn vague "what did I do?" into evidence-backed impact statements** — automatically, every Copilot CLI session.
 
 ![demo](demo/demo.gif)
 
@@ -17,6 +17,21 @@ A [GitHub Copilot CLI](https://docs.github.com/en/copilot/github-copilot-in-the-
 [![Awesome Copilot](https://img.shields.io/badge/Awesome-Copilot-blue?logo=github)](https://github.com/github/awesome-copilot)
 
 > **Requires:** Node.js 18+, [GitHub Copilot CLI](https://docs.github.com/en/copilot/github-copilot-in-the-cli) (with active Copilot subscription)
+
+## Why an extension, not just a SKILL.md?
+
+If you've seen the brag-sheet skill listed elsewhere — that's our [SKILL.md](skills/brag-sheet/SKILL.md), the LLM guidance file. It's a *prompt* that tells the agent how to think about your work. This repo ships the prompt **plus** the extension that makes it actually happen:
+
+| Just the SKILL.md | The full extension (this) |
+|---|---|
+| LLM has to remember the trigger | Auto-captures every session |
+| LLM runs shell commands by hand | Direct file/PR/git tracking via Node API |
+| LLM formats markdown each time | Deterministic, typed, crash-safe |
+| Markdown stored "somewhere" | Structured local JSON, atomic writes, orphan recovery |
+| Re-curl to update | `npm update` or one-line re-install |
+
+**Want just the prompt?** Use the skill — also published in [github/awesome-copilot](https://github.com/github/awesome-copilot).
+**Want it to actually happen automatically?** Install the extension below.
 
 ## What It Does
 
@@ -35,6 +50,14 @@ Plus three tools the agent can call on your behalf:
 | `review_brag_sheet` | Review recent entries for performance discussions |
 | `generate_work_log` | Render all records into a Markdown file |
 
+### When the agent will use this
+
+The agent picks up these tools when you say (anything close to) one of:
+
+> brag · log work · save accomplishment · what did I ship · review my work · summarize my impact · generate work log · prep my brag sheet · promo packet · perf review · Connect prep · self-review · weekly recap · monthly summary · what did I do this quarter
+
+You don't need to memorize the list — just talk naturally about your work and the agent will figure it out.
+
 ## Install (60 seconds)
 
 > ⚠️ **Don't use `copilot plugin install`.** This is a [`joinSession()`](https://docs.github.com/en/copilot/customizing-copilot/extending-copilot-with-mcp-and-extensions) extension and must live in `~/.copilot/extensions/`. Tracking [github/copilot-cli#3023](https://github.com/github/copilot-cli/issues/3023). Use one of the methods below.
@@ -43,7 +66,7 @@ Plus three tools the agent can call on your behalf:
 
 ```bash
 # macOS / Linux
-curl -sL https://raw.githubusercontent.com/microsoft/copilot-brag-sheet/main/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/microsoft/copilot-brag-sheet/main/install.sh | bash
 
 # Windows (PowerShell 5.1+)
 irm https://raw.githubusercontent.com/microsoft/copilot-brag-sheet/main/install.ps1 | iex
@@ -276,8 +299,10 @@ Default data directory:
 
 | Variable | Default | Description |
 |----------|---------|-------------|
+| `COPILOT_HOME` | `~/.copilot` | Override Copilot CLI's home dir (used by all install scripts to find/install the extension) |
 | `WORK_TRACKER_DIR` | OS app-data dir | Override the data storage directory |
 | `WORK_TRACKER_OUTPUT_PATH` | `<data-dir>/work-log.md` | Override the work log output path |
+| `BRAG_SHEET_DEBUG` | _(unset)_ | Set to `1` to log extension load events to stderr (useful for verifying the extension is hooked up) |
 
 ### config.json (optional)
 
@@ -411,7 +436,7 @@ Re-run the install script to update to the latest version:
 
 ```bash
 # macOS / Linux
-curl -sL https://raw.githubusercontent.com/microsoft/copilot-brag-sheet/main/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/microsoft/copilot-brag-sheet/main/install.sh | bash
 
 # Windows (PowerShell)
 irm https://raw.githubusercontent.com/microsoft/copilot-brag-sheet/main/install.ps1 | iex

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,51 +1,72 @@
 # Roadmap
 
-Prioritized by user impact. Contributions welcome — open an issue to discuss.
+Prioritized by impact ÷ effort. Contributions welcome — open an issue to discuss.
 
-## Priority 0 — Cross-engine (post-FHL Spring 2026)
+> **Last updated:** 2026-05-01 — reflects post-FHL distribution data + competitive analysis. We have ~218 unique visitors / 53 unique cloners in 14 days from awesome-copilot, and one organic user already (krishra). The next priorities are about converting that traffic, not polishing install scripts.
+
+## Priority 0 — Distribution & product moat (next 2 weeks)
+
+The pitch promises "automatic" but the tool requires saying "brag —". Closing that gap **and** pushing on distribution moves the project further than any installer polish.
+
+- [ ] **Summary inference** — auto-detect significant work from session signals (PR opened, on-call resolved, design merged) and prompt the user to save. Closes the README's "automatic" promise. Also the differentiator vs Microsoft's `whatidid` skill (retrospective only). [#7](https://github.com/microsoft/copilot-brag-sheet/issues/7)
+- [ ] **Publish dev.to blog post** — draft already exists at [`docs/blog-post-devto.md`](docs/blog-post-devto.md). Publish with canonical link to README. Visibility window from awesome-copilot is open NOW.
+- [ ] **GitHub Pages landing page with structured data** — JSON-LD `SoftwareApplication` + `HowTo` schema, OG tags. Goal: outrank third-party scrapers (claudskills.com) on Google searches for "brag sheet copilot".
+- [ ] **OpenGraph image** for share previews in Slack/Teams/Twitter.
+- [ ] **Reclaim attribution from claudskills.com** — they re-host our SKILL.md with no source link behind a $9/mo paywall. Polite request for attribution = free SEO backlink.
+- [ ] **Submit SKILL.md to other Claude/skill registries** — anthropic-skills awesome lists, Glama, Smithery, awesome-claude-skills. ~1 hr total.
+- [ ] **Share internally** — Microsoft Teams already shows up as a top traffic referrer organically. Post deliberately in XPP, AI org, FHL, Connect-prep channels.
+
+## Priority 1 — Cross-engine support (Agency + Claude Code)
 
 The biggest distribution unlock. See [`docs/cross-engine-spec.md`](docs/cross-engine-spec.md).
 
-- [ ] **MCP server** (`mcp-server.mjs`) — wraps the existing `lib/` modules in MCP protocol so any MCP-compatible client (Copilot CLI, Claude Code, VS Code, Codex) can use the tools
+- [ ] **MCP server** (`mcp-server.mjs`) — wraps the existing `lib/` modules in MCP protocol so any MCP-compatible client (Copilot CLI, Claude Code, VS Code, Codex) can use the tools. Resolve the spec's 5 open questions first.
 - [ ] **Hooks** (`hooks/`) — `session-start.mjs` + `session-end.mjs` for cross-engine session tracking
 - [ ] **Plugin manifest** (`.claude-plugin/plugin.json`) — declares skills, hooks, MCP server
-- [ ] **Phase 1 — Agency plugin** (internal MSFT) — ship to Xbox engineers via XPASS marketplace; works with both `agency copilot` AND `agency claude`
+- [ ] **Phase 1 — Agency plugin** (internal MSFT) — upgrade XPASS PR from skill-only to full plugin
 - [ ] **Phase 2 — Public Claude Code plugin** — `claude plugin install github:microsoft/copilot-brag-sheet`
 - [ ] **Phase 3 — npm + npx** — `npx copilot-brag-sheet mcp-server` for any MCP client
 
-## Priority 1 — Discoverability
+## Shipped
 
-- [x] **Git backup** — Opt-in auto-commit of work log to a git repo (`lib/git-backup.mjs`)
-- [x] **Git backup remote sync** — Connect data dir git repo to a remote (GitHub/ADO) for cross-machine sync
-- [x] **awesome-copilot skill** — Listed via PR #1428 (merged April 2026)
-- [x] **npm publish** — Published as `copilot-brag-sheet` (v1.0.1)
+- [x] **v1.0.3** — install bug fixes, README rewrite, plugin.json drift fix, peerDeps declaration, tarball validation in CI
+- [x] **v1.0.2** — Windows PS 5.1 install fix, npm install path (`bin/install.mjs`), Windows ESM URL fix in setup, install-smoke CI matrix, npm publish via release.yml
+- [x] **awesome-copilot skill** — listed via PR #1428 (merged April 2026)
+- [x] **npm publish** — published as `copilot-brag-sheet` (v1.0.0 → v1.0.3)
+- [x] **Git backup** — opt-in auto-commit of work log to a git repo
+- [x] **Git remote sync** — connect data dir git repo to a remote (GitHub/ADO) for cross-machine sync
 
 ### Blocked on upstream
 
-- [ ] **`copilot plugin install` support for `joinSession()` extensions** — tracking [github/copilot-cli#3023](https://github.com/github/copilot-cli/issues/3023). When fixed, we can distribute via the Copilot CLI plugin marketplace as a one-line install. Until then, manual install scripts (`install.ps1`/`install.sh`) are the only supported path for the auto-tracking functionality. Mitigation in flight: cross-engine MCP + hooks via Agency (see Priority 0).
+- [ ] **`copilot plugin install` support for `joinSession()` extensions** — tracking [github/copilot-cli#3023](https://github.com/github/copilot-cli/issues/3023) (in-repo: [#23](https://github.com/microsoft/copilot-brag-sheet/issues/23)). When fixed, distribution becomes one line. Mitigation in flight: cross-engine MCP + hooks.
 
-## Priority 3 — Features
+## Priority 2 — Polish (after distribution proven)
 
-- [ ] **Summary inference** — Auto-generate session summaries from context (issue #7)
-- [ ] **Date range filtering** — `review_brag_sheet` with custom date ranges (not just weeks) (issue #8)
-- [ ] **Export formats** — CSV and JSON export for work log data (issue #4)
+- [ ] **Trusted Publishing migration** — replace `NPM_TOKEN` with OIDC; closes the `_npmUser` vs `author:Microsoft` chain-of-trust gap. Defer until >100 weekly installs.
+- [ ] **`mktemp -d` staging in install.sh** — atomic install (current `rm -rf` before clone is real upgrade-path regression risk if clone fails)
+- [ ] **EBUSY handling on Windows in-place upgrade** — `bin/install.mjs:rmSync` throws if Copilot CLI is running
+- [ ] **ANSI escape gating** — `isTTY && !process.env.NO_COLOR`
+- [ ] **Verify extension actually loads** in `copilot -p` and other contexts (with `BRAG_SHEET_DEBUG=1` debug log added in v1.0.3)
 
-## Priority 4 — Personalization
+## Priority 3 — Features (issue tracker)
 
-- [ ] **User-defined tracking preferences** — `impactDefinition`, `trackingFocus`, `outputFormat` fields in config.json
-- [ ] **STAR output format** — Situation/Task/Action/Result template for entries (issue #9)
-- [ ] **Additional presets** — Beyond Microsoft (e.g., Google, generic startup)
+- [ ] **Date range filtering** — `review_brag_sheet` with custom date ranges (issue [#8](https://github.com/microsoft/copilot-brag-sheet/issues/8))
+- [ ] **Export formats** — CSV and JSON export (issue [#4](https://github.com/microsoft/copilot-brag-sheet/issues/4))
+- [ ] **STAR output format** — Situation/Task/Action/Result template (issue [#9](https://github.com/microsoft/copilot-brag-sheet/issues/9))
+- [ ] **User-defined tracking preferences** — `impactDefinition`, `trackingFocus`, `outputFormat` in config.json
+- [ ] **Additional presets** — beyond Microsoft (e.g., generic startup, Google)
 
-## Priority 5 — Hardening
+## Priority 4 — Hardening
 
-- [ ] **Case-insensitive path dedup** — Windows/macOS case-insensitive file path deduplication
-- [ ] **UNC path handling** — Fix `normalizePath` for Windows UNC paths (`\\server\share`)
+- [ ] **Case-insensitive path dedup** — Windows/macOS file path deduplication
+- [ ] **UNC path handling** — fix `normalizePath` for `\\server\share`
 
 ## Non-Goals
 
 These are intentionally out of scope:
 
-- **Cloud storage backend** — local-first tool; use cloud sync (OneDrive/Dropbox) instead
+- **Cloud storage backend** — local-first; use cloud sync (OneDrive/Dropbox) instead
 - **Runtime dependencies** — zero-dependency constraint is a feature
 - **Telemetry or analytics** — no data leaves your machine
 - **Multi-user features** — personal productivity tool
+- **In-product `update-notifier`** — would corrupt agent transcripts (extension stdio is the host's tool-output channel) AND breaks zero-deps promise. Use `npm update -g` instead.

--- a/bin/install.mjs
+++ b/bin/install.mjs
@@ -17,7 +17,7 @@ import {
   readFileSync,
 } from "node:fs";
 import { join, dirname } from "node:path";
-import { fileURLToPath, pathToFileURL } from "node:url";
+import { fileURLToPath } from "node:url";
 import { homedir } from "node:os";
 import { spawnSync } from "node:child_process";
 
@@ -31,7 +31,6 @@ const TARGET_DIR = join(COPILOT_HOME, "extensions", "copilot-brag-sheet");
 // ── Helpers ─────────────────────────────────────────────────────────────────
 function green(s) { return `\x1b[32m${s}\x1b[0m`; }
 function bold(s) { return `\x1b[1m${s}\x1b[0m`; }
-function dim(s) { return `\x1b[2m${s}\x1b[0m`; }
 
 // ── Preflight ───────────────────────────────────────────────────────────────
 const nodeMajor = Number(process.versions.node.split(".")[0]);
@@ -58,13 +57,7 @@ if (existsSync(TARGET_DIR)) {
 }
 mkdirSync(TARGET_DIR, { recursive: true });
 
-// Copy package contents (excluding node_modules + .git + tests)
-const SKIP = new Set([
-  "node_modules", ".git", ".github", "test", "docs",
-  "AGENTS.md", "CONTRIBUTING.md", "ROADMAP.md", "CODEOWNERS",
-  "CHANGELOG.md", "CODE_OF_CONDUCT.md", "SECURITY.md",
-  "install.sh", "install.ps1",
-]);
+// Copy package contents — only what the extension needs at runtime
 for (const entry of REQUIRED) {
   cpSync(join(PKG_ROOT, entry), join(TARGET_DIR, entry), { recursive: true });
 }
@@ -90,11 +83,8 @@ if (process.stdin.isTTY && existsSync(setupScript)) {
   console.log(green(bold("🎉 Installed!")));
   console.log("");
   console.log("  Next steps:");
-  console.log(`    1. Run the setup wizard:  node ${setupScript}`);
+  console.log(`    1. Run the setup wizard:  copilot-brag-sheet-setup`);
   console.log("    2. Run /clear in Copilot CLI (or restart it)");
   console.log("    3. Say \"brag\" to save an accomplishment");
   console.log("");
 }
-
-// Silence unused import warning (kept for potential future use in setup-import)
-void pathToFileURL;

--- a/bin/setup.mjs
+++ b/bin/setup.mjs
@@ -46,12 +46,14 @@ function git(args, cwd, { timeout: t = 5000 } = {}) {
 
 async function main() {
   // Setup wizard requires an interactive terminal — reading from a pipe or
-  // headless context (CI, Docker, npm scripts) would hang indefinitely on the
-  // first prompt. Detect early and exit with a clear message.
+  // headless context (CI, Docker, npm scripts, irm | iex) would hang
+  // indefinitely on the first prompt. Detect early and skip cleanly.
+  // Exit 0 (not an error) — setup is optional; install is already done.
   if (!process.stdin.isTTY) {
     console.error("");
-    console.error("  setup requires an interactive terminal.");
-    console.error("  Run from a TTY, or set values directly in:");
+    console.error("  Skipping interactive setup — no TTY detected.");
+    console.error("  Re-run from a terminal:  copilot-brag-sheet-setup");
+    console.error("  Or set values directly in:");
     try {
       const dir = (await import(pathToFileURL(join(LIB_DIR, "paths.mjs")).href)).detectDataDir();
       console.error(`    ${join(dir, "config.json")}`);
@@ -59,7 +61,7 @@ async function main() {
       console.error("    <data-dir>/config.json");
     }
     console.error("");
-    process.exit(2);
+    process.exit(0);
   }
 
   process.on("SIGINT", () => {

--- a/bin/setup.mjs
+++ b/bin/setup.mjs
@@ -45,6 +45,23 @@ function git(args, cwd, { timeout: t = 5000 } = {}) {
 // ── Main ────────────────────────────────────────────────────────────────────
 
 async function main() {
+  // Setup wizard requires an interactive terminal — reading from a pipe or
+  // headless context (CI, Docker, npm scripts) would hang indefinitely on the
+  // first prompt. Detect early and exit with a clear message.
+  if (!process.stdin.isTTY) {
+    console.error("");
+    console.error("  setup requires an interactive terminal.");
+    console.error("  Run from a TTY, or set values directly in:");
+    try {
+      const dir = (await import(pathToFileURL(join(LIB_DIR, "paths.mjs")).href)).detectDataDir();
+      console.error(`    ${join(dir, "config.json")}`);
+    } catch {
+      console.error("    <data-dir>/config.json");
+    }
+    console.error("");
+    process.exit(2);
+  }
+
   process.on("SIGINT", () => {
     console.log("\n\n  Setup cancelled. Run again anytime to finish.\n");
     process.exit(130);

--- a/extension.mjs
+++ b/extension.mjs
@@ -30,6 +30,12 @@ import {
 } from "./lib/records.mjs";
 import { renderMarkdown, renderReviewSummary } from "./lib/render.mjs";
 
+// Debug: log to stderr at module load time so we can verify the host actually loaded us.
+// Gated on env var to avoid noise in normal sessions. Set BRAG_SHEET_DEBUG=1 to enable.
+if (process.env.BRAG_SHEET_DEBUG) {
+  process.stderr.write("[brag-sheet] extension module loaded\n");
+}
+
 // ── Module-level state (one session per extension process) ──────────────────
 
 let dataDir = null;
@@ -190,6 +196,9 @@ function detectShellGitAction(command) {
 const session = await joinSession({
   hooks: {
     onSessionStart: async (input, invocation) => {
+      if (process.env.BRAG_SHEET_DEBUG) {
+        process.stderr.write("[brag-sheet] onSessionStart called\n");
+      }
       try {
         dataDir = detectDataDir();
         ensureDir(dataDir);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "copilot-brag-sheet",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Auto-track AI coding sessions into a structured work log. Zero dependencies, local-first.",
   "type": "module",
   "main": "extension.mjs",
@@ -9,7 +9,8 @@
     "copilot-brag-sheet-setup": "./bin/setup.mjs"
   },
   "scripts": {
-    "test": "node --test"
+    "test": "node --test",
+    "prepublishOnly": "node --test"
   },
   "keywords": [
     "copilot",
@@ -31,6 +32,14 @@
   },
   "engines": {
     "node": ">=18.0.0"
+  },
+  "peerDependencies": {
+    "@github/copilot": ">=1.0.0"
+  },
+  "peerDependenciesMeta": {
+    "@github/copilot": {
+      "optional": true
+    }
   },
   "files": [
     "extension.mjs",

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,6 @@
 {
   "name": "copilot-brag-sheet",
   "description": "Auto-track AI coding sessions into a structured work impact log. Zero dependencies, local-first.",
-  "version": "1.0.0",
   "author": {
     "name": "Microsoft",
     "url": "https://www.microsoft.com"


### PR DESCRIPTION
## Summary

Batched v1.0.3 release combining install bug fixes (caught by an independent skeptic-agent review) + README rewrite (per UX critique + competitive analysis) + ROADMAP refocus (per architect-agent verdict + post-FHL traffic data).

## Bug fixes
| # | Issue | Severity |
|---|---|---|
| 1 | `plugin.json` version hardcoded `1.0.0` while `package.json` had moved to `1.0.2` | **P1 — drift, mislead Copilot host UI** |
| 2 | `bin/setup.mjs` hangs forever on non-TTY stdin (CI, Docker, headless) | P1 — silent install failure |
| 3 | README curl one-liners use `-sL` instead of `-fsSL` | P2 — HTTP error pipes HTML to bash |

## Features
- **`@github/copilot` declared as optional `peerDependency`** — gives static-analysis tools a hook without forcing install on end users (host injects it at load time)
- **`copilot-brag-sheet-setup` bin** — re-run wizard without remembering absolute path
- **`BRAG_SHEET_DEBUG=1` env var** — logs extension load events to stderr; lets us verify the host actually loaded the extension in different contexts (e.g., `copilot -p`)
- **`prepublishOnly` script** — runs `npm test` automatically before local `npm publish` (defense in depth)
- **CI: tarball validation** — checks `npm pack --dry-run` against required-files list before publish. Catches future cases where new `lib/foo.mjs` is added but missed in `package.json` `files` whitelist.

## README rewrite (UX critique + competitive analysis)

claudskills.com mirrors our SKILL.md verbatim with no attribution. The rewrite positions the **moat** (full extension > just the prompt):

- **Stronger hero**: "Turn vague *what did I do?* into evidence-backed impact statements" (matches our SKILL.md frontmatter — already winning on third-party sites)
- **New "Why an extension, not just a SKILL.md?" section** — feature ladder
- **"When the agent will use this"** trigger phrases section
- **`COPILOT_HOME` documented** in Environment Variables

## ROADMAP refocus (post-FHL traffic data)

We have **218 unique visitors / 53 unique cloners** in 14 days from awesome-copilot, plus organic traffic from Microsoft Teams. Roadmap restructured:

- **Priority 0 = distribution + product moat** (summary inference, blog post, SEO landing page, claudskills attribution reclaim, Teams sharing)
- **Priority 1 = cross-engine** (Agency + Claude Code via MCP + hooks per `docs/cross-engine-spec.md`)
- **Priority 2 = packaging polish** (mktemp staging, EBUSY handling, Trusted Publishing — deferred until distribution proven)
- **Non-goals expanded**: `update-notifier` would corrupt agent transcripts (extension stdio is host's tool channel) AND breaks zero-deps promise

## Cleanup
- Removed dead code in `bin/install.mjs` (`SKIP` set never used; `pathToFileURL` imported then voided)

## Verification

Locally on real Windows PowerShell 5.1:
- ✅ 107 tests pass
- ✅ TTY guard: spawned wizard with non-TTY stdin → exits clean code 2 with helpful message (no hang)
- ✅ Install ends with `package.json` v1.0.3, `plugin.json` no longer has `version` field (single source of truth)
- ✅ `npm pack --dry-run` shows all 14 required files in tarball

CI matrix on this PR exercises install scripts on ubuntu/macOS/PS5.1/PS7+.

After merge: tag `v1.0.3` → release.yml auto-publishes to npm (with new tarball validation gate).