### PR TITLE
fix(ci): tarball validation script (bash + jq)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,7 +54,7 @@ jobs:
           # Required files that must be in the published tarball.
           # If we add a new lib/foo.mjs and forget to update package.json's "files"
           # whitelist, this catches it before the broken publish goes out.
-          REQUIRED=(
+          required=(
             extension.mjs
             plugin.json
             package.json
@@ -69,32 +69,17 @@ jobs:
             lib/storage.mjs
           )
           npm pack --dry-run --json > /tmp/pack.json
-          node -e "
-            const required = process.env.REQUIRED.split('\n').filter(Boolean);
-            const pack = JSON.parse(require('fs').readFileSync('/tmp/pack.json', 'utf8'));
-            const got = new Set(pack[0].files.map(f => f.path));
-            const missing = required.filter(f => !got.has(f));
-            if (missing.length) {
-              console.error('::error::Missing in tarball:');
-              missing.forEach(f => console.error('  - ' + f));
-              process.exit(1);
-            }
-            console.log('Tarball contains all', required.length, 'required files.');
-          "
-        env:
-          REQUIRED: |
-            extension.mjs
-            plugin.json
-            package.json
-            bin/install.mjs
-            bin/setup.mjs
-            lib/config.mjs
-            lib/git-backup.mjs
-            lib/lock.mjs
-            lib/paths.mjs
-            lib/records.mjs
-            lib/render.mjs
-            lib/storage.mjs
+          missing=()
+          for f in "${required[@]}"; do
+            jq -e --arg f "$f" '.[0].files[] | select(.path == $f)' /tmp/pack.json > /dev/null \
+              || missing+=("$f")
+          done
+          if [ ${#missing[@]} -gt 0 ]; then
+            echo "::error::Missing in tarball:"
+            printf '  - %s\n' "${missing[@]}"
+            exit 1
+          fi
+          echo "Tarball contains all ${#required[@]} required files."
 
       - name: Extract changelog for this version
         id: changelog


### PR DESCRIPTION
v1.0.3 release workflow failed because my new tarball-validation step had a subtle bug: my bash `REQUIRED=(...)` array assignment shadowed the env-level `REQUIRED` var, so `node -e` saw `process.env.REQUIRED === undefined`.

Cleaner fix: pure bash + jq (already on every GitHub-hosted runner). No env-var-shadowing footgun.

After this lands, re-tagging v1.0.3 (or v1.0.4) will properly publish to npm.