### PR TITLE
feat(mcp): rewrite server on official MCP SDK + add 10-question eval suite

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-plugin.json",
+  "name": "copilot-brag-sheet",
+  "version": "1.0.3",
+  "description": "Auto-track AI coding sessions into a structured work impact log. Zero dependencies, local-first. Cross-engine: Claude Code, Copilot CLI, Codex CLI, Cursor, Agency.",
+  "author": {
+    "name": "Microsoft",
+    "url": "https://github.com/microsoft/copilot-brag-sheet"
+  },
+  "homepage": "https://github.com/microsoft/copilot-brag-sheet",
+  "license": "MIT",
+  "keywords": [
+    "brag-sheet",
+    "work-tracker",
+    "impact-log",
+    "developer-productivity",
+    "performance-review",
+    "local-first"
+  ],
+  "skills": [
+    "./skills/brag-sheet/SKILL.md"
+  ],
+  "mcpServers": {
+    "brag-sheet": {
+      "command": "node",
+      "args": ["${CLAUDE_PLUGIN_ROOT}/bin/mcp-server.mjs"],
+      "description": "Save, review, and export brag-sheet entries via MCP."
+    }
+  }
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin.json",
   "name": "copilot-brag-sheet",
   "version": "1.0.3",
-  "description": "Auto-track AI coding sessions into a structured work impact log. Zero dependencies, local-first. Cross-engine: Claude Code, Copilot CLI, Codex CLI, Cursor, Agency.",
+  "description": "Auto-track AI coding sessions into a structured work impact log. Local-first, MCP-conformant. Cross-engine: Claude Code, Copilot CLI, Codex CLI, Cursor, Agency.",
   "author": {
     "name": "Microsoft",
     "url": "https://github.com/microsoft/copilot-brag-sheet"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,7 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
+      - run: npm ci --no-audit --no-fund
       - run: npm test
 
   release:
@@ -35,6 +36,8 @@ jobs:
         with:
           node-version: 20
           registry-url: 'https://registry.npmjs.org/'
+
+      - run: npm ci --no-audit --no-fund
 
       - name: Extract version from tag
         id: version
@@ -56,10 +59,12 @@ jobs:
           # whitelist, this catches it before the broken publish goes out.
           required=(
             extension.mjs
+            mcp-server.mjs
             plugin.json
             package.json
             bin/install.mjs
             bin/setup.mjs
+            bin/mcp-server.mjs
             lib/config.mjs
             lib/git-backup.mjs
             lib/lock.mjs
@@ -67,6 +72,10 @@ jobs:
             lib/records.mjs
             lib/render.mjs
             lib/storage.mjs
+            .claude-plugin/plugin.json
+            evals/brag-sheet.eval.xml
+            evals/fixtures/entries.json
+            evals/seed.mjs
           )
           npm pack --dry-run --json > /tmp/pack.json
           missing=()

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,8 @@ errors.log
 .DS_Store
 Thumbs.db
 test-temp-config-*/
+# WSL/local debug scripts produced while probing the MCP server.
+debug-mcp.sh
+test-mcp-wsl*.sh
+*.tgz
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules/
 *.lock
+package-lock.json
 *.tmp.*
 errors.log
 .DS_Store

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,8 +21,11 @@ created, git actions, manual brag entries — into structured local JSON so a
 developer has receipts at performance review time instead of a blank page.
 It ships as a [`joinSession()`](https://docs.github.com/en/copilot/customizing-copilot/extending-copilot-with-mcp-and-extensions)
 extension installed into `~/.copilot/extensions/copilot-brag-sheet/`,
-runs entirely on the user's machine, has **zero runtime dependencies**, and
-emits **zero telemetry**. The user-facing pitch is:
+runs entirely on the user's machine, and emits **zero telemetry**. The
+core library (`lib/`) is dependency-free; the cross-engine MCP server
+(`mcp-server.mjs`) takes two pinned, audited runtime dependencies — the
+official MCP SDK and Zod — to stay protocol-conformant. The user-facing
+pitch is:
 
 > Turn vague *what did I do?* into evidence-backed impact statements —
 > automatically, every Copilot CLI session.
@@ -67,7 +70,8 @@ Copilot CLI host  ──spawns──▶  extension.mjs (joinSession)
 | [`bin/setup.mjs`](bin/setup.mjs) | Interactive wizard: presets, git backup, output path. Non-TTY exits cleanly (CI-safe). |
 | [`install.sh`](install.sh) / [`install.ps1`](install.ps1) | Curl-pipe-bash installers. Cross-platform CI-tested on PS 5.1 and pwsh 7. |
 
-**Core library** (`lib/`) — zero deps, pure Node, Copilot-agnostic:
+**Core library** (`lib/`) — dependency-free, pure Node, Copilot-agnostic
+(safe to import from any entry point):
 
 | Module | Responsibility | Key exports |
 |---|---|---|
@@ -129,10 +133,10 @@ $env:COPILOT_HOME = "$env:TEMP\copilot-home-test"
 Get-ChildItem $env:COPILOT_HOME\extensions\copilot-brag-sheet
 ```
 
-**There is no `npm install` step for contributors** — the repo has zero
-runtime dependencies and no devDependencies. Cloning and running
-`npm test` Just Works. If a future change ever requires `npm install`,
-that's a red flag — see §10.
+**Contributors must run `npm install` before `npm test`** because
+`mcp-server.mjs` depends on the MCP SDK and Zod (see §4 conventions).
+The `lib/` modules and `extension.mjs` themselves remain dependency-free;
+only the MCP entry point pulls runtime deps.
 
 ---
 
@@ -141,9 +145,14 @@ that's a red flag — see §10.
 These are non-negotiable. Most of them encode hard-won lessons (CI failures,
 real bug reports). Don't change them without an issue and discussion first.
 
-- **Zero runtime dependencies.** `package.json` has no `dependencies`. Only
-  `peerDependencies` (the Copilot SDK, declared `optional`). If you reach
-  for npm, stop and use `node:` built-ins.
+- **Minimal, pinned runtime dependencies.** `package.json` has exactly
+  two runtime `dependencies`: `@modelcontextprotocol/sdk` (cross-engine
+  MCP transport) and `zod` (input/output schema validation in
+  `mcp-server.mjs`). Both are required for MCP protocol conformance.
+  `lib/*` and `extension.mjs` remain dependency-free — they MUST NOT
+  import either package directly. Any new runtime dependency requires
+  an issue, a written rationale, and an update to this section in the
+  same PR. `peerDependencies` lists the Copilot SDK as `optional`.
 - **ESM only.** `.mjs` everywhere, `"type": "module"` in `package.json`.
   No CommonJS. No transpilation. Use `node:`-prefixed imports
   (`node:fs`, `node:path`, `node:crypto`, `node:child_process`).
@@ -380,10 +389,12 @@ proving distribution conversion before fanning out further.
 
 > If you're tempted to do any of these, **stop and open an issue first.**
 
-1. **Add a runtime dependency.** Zero deps is a feature. It's the answer
-   to half the install bugs in `CHANGELOG.md`. If you need
-   functionality, write it in `lib/` against `node:` built-ins. There is
-   no `npm install` for contributors and we want to keep it that way.
+1. **Add a runtime dependency without an issue + rationale.** Two
+   pinned deps (the MCP SDK and Zod, both required for protocol
+   conformance in `mcp-server.mjs`) is the entire approved list. Any
+   third dep needs an issue, a written justification, an audit note,
+   and an update to §4 in the same PR. `lib/` and `extension.mjs`
+   stay dependency-free regardless.
 2. **Write JSON non-atomically.** Always go through
    [`atomicWriteJSON`](lib/storage.mjs:216). A `writeFileSync` straight to
    the final path will eventually corrupt the user's history during a
@@ -404,8 +415,10 @@ proving distribution conversion before fanning out further.
 6. **Add an `update-notifier` or any in-process "you should update" UI.**
    Same reason as above — stdio is sacred. Plus it would break zero
    deps. Users update via `npm update -g`.
-7. **Use `npm install` for a runtime dep.** See #1. There are exactly
-   zero approved exceptions today.
+7. **Add a runtime dep to `lib/` or `extension.mjs`.** These two
+   surfaces stay dependency-free. New runtime deps are only allowed in
+   `mcp-server.mjs` and need the §4 process (issue + rationale + same-PR
+   update to §4).
 8. **Bypass `sanitize()` when persisting LLM/user text.** Reserved
    markers, pipe chars, leading `#`, and length must always be filtered.
    See `lib/records.mjs:50-71`.
@@ -491,7 +504,7 @@ Five-step recipes. Pick the one that matches your task; deviate only with reason
 
 ### How to add a new lib module
 
-1. Create `lib/<name>.mjs` — pure Node, zero deps, `node:`-prefixed
+1. Create `lib/<name>.mjs` — pure Node, dependency-free, `node:`-prefixed
    imports, `export`ed functions only.
 2. Create `test/<name>.test.mjs` mirroring it.
 3. Add the file to `package.json`'s `files` array.
@@ -526,8 +539,8 @@ Five-step recipes. Pick the one that matches your task; deviate only with reason
 Add an entry here when **any** of these is true:
 
 1. **An agent made the same mistake twice** — the rule prevents
-   recurrence (e.g. §10.1 "no runtime deps" exists because the v1.0.1
-   bug was a side-effect of one).
+   recurrence (e.g. §10.1 "no runtime deps without process" exists
+   because adding one without updating §4 created a doc/code split).
 2. **A code review or release-job caught something an agent should
    have known** — e.g. §10.9 "files array + release.yml required
    array" entered after a publish failure.
@@ -535,6 +548,13 @@ Add an entry here when **any** of these is true:
    is the load-bearing signal that the file is too thin.
 4. **A new teammate (human or AI) would need this context to ship
    safely** — onboarding-grade facts belong in §1, §2, or §9.
+
+**Process rule for §4 "non-negotiable" changes:** if a PR breaks a §4
+convention, the same PR must update §4 to reflect the new contract.
+Splitting the code change and the doc change into separate PRs leaves
+agents reading stale rules and "fixing" the new code out from under
+itself. This rule exists because the v1.0.4 MCP SDK adoption initially
+shipped without flipping the §4 "zero runtime dependencies" line.
 
 Conversely, **delete** entries when:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,11 @@ cd copilot-brag-sheet
 npm test
 ```
 
-No `npm install` needed — zero dependencies.
+Then install runtime deps (`@modelcontextprotocol/sdk` and `zod` for the MCP server):
+
+```bash
+npm install
+```
 
 ## Project Structure
 
@@ -58,7 +62,7 @@ These are intentional constraints — please don't change them without discussio
 
 | Decision | Rationale |
 |----------|-----------|
-| Zero dependencies | Runs anywhere Node 18+ exists |
+| Minimal runtime deps | Only `@modelcontextprotocol/sdk` + `zod` (MCP server only); `lib/` stays pure Node |
 | No SQLite | Node 18 built-in SQLite is not available |
 | JSON records only | Cloud-sync safe, human-readable |
 | Atomic writes (tmp→fsync→rename) | Crash-safe, OneDrive/iCloud safe |

--- a/README.md
+++ b/README.md
@@ -469,7 +469,7 @@ Your data stays in the OS app-data directory — delete it manually if you want 
 <details>
 <summary><strong>Does this send my data anywhere?</strong></summary>
 
-No. All data is stored locally in your OS app-data directory. Zero telemetry, zero network calls. The extension has zero runtime dependencies. If you enable git push, data goes only to a remote you configure.
+No. All data is stored locally in your OS app-data directory. Zero telemetry, zero network calls. The core library has no runtime dependencies; the cross-engine MCP server (`mcp-server.mjs`) uses the official MCP SDK and Zod. If you enable git push, data goes only to a remote you configure.
 </details>
 
 <details>
@@ -506,7 +506,7 @@ Enable git backup in your config, add a remote repo, and your entries sync autom
 
 - Node.js 18+
 - [GitHub Copilot CLI](https://docs.github.com/en/copilot/github-copilot-in-the-cli)
-- Zero runtime dependencies
+- Local-first: data stays on your machine, no telemetry
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ![demo](demo/demo.gif)
 
-**🔒 Local-first · 📦 Zero dependencies · 🚫 Zero telemetry**
+**🔒 Local-first · 🤝 MCP-conformant · 🚫 Zero telemetry**
 
 A [GitHub Copilot CLI](https://docs.github.com/en/copilot/github-copilot-in-the-cli) extension that silently records your work as you go — files edited, PRs created, git actions — so when performance review season hits, you have receipts instead of a blank page. ([What's a brag sheet?](https://jvns.ca/blog/brag-documents/))
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -66,7 +66,7 @@ See [`docs/cross-engine-spec.md`](docs/cross-engine-spec.md).
 These are intentionally out of scope:
 
 - **Cloud storage backend** — local-first; use cloud sync (OneDrive/Dropbox) instead
-- **Runtime dependencies** — zero-dependency constraint is a feature
+- **Heavy runtime dependencies** — minimal-dep constraint is a feature; only the official MCP SDK + Zod are accepted (for spec conformance)
 - **Telemetry or analytics** — no data leaves your machine
 - **Multi-user features** — personal productivity tool
-- **In-product `update-notifier`** — would corrupt agent transcripts (extension stdio is the host's tool-output channel) AND breaks zero-deps promise. Use `npm update -g` instead.
+- **In-product `update-notifier`** — would corrupt agent transcripts (extension stdio is the host's tool-output channel) AND adds a runtime dep with no protocol-conformance benefit. Use `npm update -g` instead.

--- a/bin/install.mjs
+++ b/bin/install.mjs
@@ -13,6 +13,7 @@ import {
   cpSync,
   existsSync,
   mkdirSync,
+  readdirSync,
   rmSync,
   readFileSync,
 } from "node:fs";
@@ -39,7 +40,13 @@ if (nodeMajor < 18) {
   process.exit(1);
 }
 
-// Verify the package source has the files we expect
+// Verify the package source has the files we expect.
+//
+// `bin/mcp-server.mjs` is intentionally NOT included here — the MCP server
+// is delivered as an npm bin (`npx -y --package copilot-brag-sheet
+// copilot-brag-sheet-mcp`), not from the Copilot extension layout. Copying
+// it into ~/.copilot/extensions/ would also need ../mcp-server.mjs and its
+// node_modules, which the install path cannot guarantee.
 const REQUIRED = ["extension.mjs", "package.json", "plugin.json", "lib", "bin"];
 const missing = REQUIRED.filter((p) => !existsSync(join(PKG_ROOT, p)));
 if (missing.length) {
@@ -47,6 +54,10 @@ if (missing.length) {
   console.error(`  Looked in: ${PKG_ROOT}`);
   process.exit(1);
 }
+
+// Files to skip when copying bin/. The MCP server entry is published via
+// the npm `bin` and is not part of the Copilot extension install layout.
+const BIN_SKIP = new Set(["mcp-server.mjs"]);
 
 // ── Install ─────────────────────────────────────────────────────────────────
 const pkg = JSON.parse(readFileSync(join(PKG_ROOT, "package.json"), "utf8"));
@@ -57,9 +68,21 @@ if (existsSync(TARGET_DIR)) {
 }
 mkdirSync(TARGET_DIR, { recursive: true });
 
-// Copy package contents — only what the extension needs at runtime
+// Copy package contents — only what the extension needs at runtime.
+// bin/ is copied piecewise so the MCP server bin (which depends on
+// ../mcp-server.mjs and node_modules) is excluded from this layout.
 for (const entry of REQUIRED) {
-  cpSync(join(PKG_ROOT, entry), join(TARGET_DIR, entry), { recursive: true });
+  if (entry !== "bin") {
+    cpSync(join(PKG_ROOT, entry), join(TARGET_DIR, entry), { recursive: true });
+    continue;
+  }
+  mkdirSync(join(TARGET_DIR, "bin"), { recursive: true });
+  for (const f of readdirSync(join(PKG_ROOT, "bin"))) {
+    if (BIN_SKIP.has(f)) continue;
+    cpSync(join(PKG_ROOT, "bin", f), join(TARGET_DIR, "bin", f), {
+      recursive: true,
+    });
+  }
 }
 // Also copy README + LICENSE if present (npm tarball includes them)
 for (const opt of ["README.md", "LICENSE"]) {

--- a/bin/mcp-server.mjs
+++ b/bin/mcp-server.mjs
@@ -3,8 +3,15 @@
  * Shebang entry point so the MCP server can be launched by name via npm
  * `bin` registration. All behaviour lives in ../mcp-server.mjs.
  *
- *   npx copilot-brag-sheet-mcp
- *   claude mcp add --transport stdio brag-sheet -- npx copilot-brag-sheet-mcp
+ * Invoke from a published package via `npm exec`:
+ *   npx -y --package copilot-brag-sheet copilot-brag-sheet-mcp
+ *
+ * Wire into Claude Code:
+ *   claude mcp add brag-sheet -- npx -y --package copilot-brag-sheet copilot-brag-sheet-mcp
+ *
+ * (Plain `npx copilot-brag-sheet-mcp` does NOT work — `copilot-brag-sheet-mcp`
+ * is a bin entry inside the `copilot-brag-sheet` package, not its own
+ * package on the registry, so `npx` cannot resolve the name on its own.)
  */
 import { runServer } from "../mcp-server.mjs";
 

--- a/bin/mcp-server.mjs
+++ b/bin/mcp-server.mjs
@@ -1,0 +1,9 @@
+#!/usr/bin/env node
+/**
+ * Thin shebang wrapper so the MCP server can be launched by name via npm
+ * `bin` registration. All behaviour lives in ../mcp-server.mjs.
+ *
+ *   npx copilot-brag-sheet-mcp
+ *   claude mcp add --transport stdio brag-sheet -- npx copilot-brag-sheet-mcp
+ */
+import "../mcp-server.mjs";

--- a/bin/mcp-server.mjs
+++ b/bin/mcp-server.mjs
@@ -1,9 +1,15 @@
 #!/usr/bin/env node
 /**
- * Thin shebang wrapper so the MCP server can be launched by name via npm
+ * Shebang entry point so the MCP server can be launched by name via npm
  * `bin` registration. All behaviour lives in ../mcp-server.mjs.
  *
  *   npx copilot-brag-sheet-mcp
  *   claude mcp add --transport stdio brag-sheet -- npx copilot-brag-sheet-mcp
  */
-import "../mcp-server.mjs";
+import { runServer } from "../mcp-server.mjs";
+
+runServer().catch((err) => {
+  process.stderr.write(`[brag-sheet mcp] fatal: ${err?.stack || err}\n`);
+  process.exit(1);
+});
+

--- a/docs/blog-post-devto.md
+++ b/docs/blog-post-devto.md
@@ -37,7 +37,7 @@ That's [`copilot-brag-sheet`](https://github.com/microsoft/copilot-brag-sheet).
 
 ## How it works
 
-Zero dependencies, Node 18+, runs everywhere.
+Local-first, Node 18+, runs everywhere.
 
 ```
 ┌─────────────────┐    hooks     ┌──────────────────┐
@@ -102,11 +102,11 @@ Every entry follows the same format: **Did X → Result Y → Evidence Z**. If y
 
 I originally just did `fs.writeFile`. Then OneDrive sync grabbed a half-written JSON file mid-write and corrupted my entire month. Now every write is `tmp file → fsync → rename`, which is atomic on every OS I care about.
 
-**2. Zero dependencies was worth the pain.**
+**2. Keeping the dep tree narrow was worth the pain.**
 
-I wanted SQLite. Node 18 doesn't have built-in SQLite. I wanted YAML. That's a parser dep. Each one is fine in isolation, but a tool that lives in your shell config and runs on every session start should not have a `node_modules` graph. JSON files in sharded directories turned out to be plenty.
+I wanted SQLite. Node 18 doesn't have built-in SQLite. I wanted YAML. That's a parser dep. Each one is fine in isolation, but a tool that lives in your shell config and runs on every session start should not have a sprawling `node_modules` graph. JSON files in sharded directories turned out to be plenty. The extension itself stays pure Node; only the optional MCP server pulls in `@modelcontextprotocol/sdk` + `zod` for spec conformance.
 
-107 tests, all green, no `node_modules`. That part feels good.
+107 tests, all green, a tiny dep tree. That part feels good.
 
 ## Try it
 

--- a/docs/cross-engine-decisions.md
+++ b/docs/cross-engine-decisions.md
@@ -1,0 +1,120 @@
+# Cross-Engine Spec — Decisions
+
+> Companion to [`cross-engine-spec.md`](./cross-engine-spec.md). Records the
+> resolution of the five open questions left at the bottom of that spec, so
+> future readers know *why* the v1.1 scaffold looks the way it does.
+
+**Decided:** 2025-05 (during MCP-server scaffold PR).
+**Scope of this doc:** decisions only. The "Architecture" and "What's
+Reusable" sections of the parent spec stand unchanged.
+
+---
+
+## 1. Zero-dep vs SDK → **zero-dep, hand-roll JSON-RPC**
+
+**Decision:** Implement MCP over stdio by hand. Do **not** add
+`@modelcontextprotocol/sdk` (or any other runtime dep) to `package.json`.
+
+**Why:**
+
+- The package's brand promise ("Zero dependencies, local-first") is in the
+  README, the npm description, the SKILL.md, and the marketplace
+  submissions. Breaking it for a transport shim is a bad trade.
+- The MCP wire protocol we need is small: `initialize`, `tools/list`,
+  `tools/call`, `ping`, plus newline-delimited JSON framing. ~50 lines of
+  hand-rolled code vs a transitive dep tree.
+- All real work (storage, render, git backup) already lives in `lib/` —
+  the SDK would only manage the transport, which is the easy part.
+
+**Cost:** We own the framing/dispatch code. If MCP adds new required
+features (e.g. resources, prompts, sampling), we update one file.
+
+**File:** [`mcp-server.mjs`](../mcp-server.mjs) at repo root.
+
+---
+
+## 2. Hook state persistence → **defer hooks entirely to v2**
+
+**Decision:** The first cross-engine release ships **MCP only**. No
+`hooks/`, no `hooks.json`, no `session-start.mjs` / `session-end.mjs`.
+
+**Why:**
+
+- MCP unblocks every host that doesn't speak Copilot's `joinSession()` —
+  Claude Code, Codex CLI, Cursor, Agency — which is the actual user
+  request.
+- Hooks add real complexity (process boundaries, state passing, engine
+  differences) for the *auto-tracking* feature, which is a nice-to-have
+  layered on top of the core tools.
+- A correctly designed hook story needs answers to question 3 (file
+  tracking) that we don't have without prototyping inside Claude Code.
+- Shipping MCP-only first lets us validate the lib/ surface across hosts
+  before locking in a hook contract that has to work everywhere.
+
+**Follow-up:** Track in [issue #22] under a separate "v2: hooks" milestone.
+The Copilot-CLI auto-tracking continues to work via the existing
+`extension.mjs` → `joinSession()` path; nothing regresses.
+
+---
+
+## 3. File tracking in Claude Code hooks → **deferred (with v2)**
+
+**Decision:** Out of scope for this PR. See question 2.
+
+**Why:** Claude Code's hook surface (`PreToolUse`, `PostToolUse`,
+`SessionEnd`, etc.) does expose tool invocations including `Edit` and
+`Write`, so the answer is almost certainly "yes, we can mirror what
+`onPostToolUse` does today" — but the exact event shapes and how they
+interact with subagents need a working prototype before we commit to a
+contract. That prototype belongs in the v2 hooks PR, not here.
+
+---
+
+## 4. Backward compat for `extension.mjs` → **keep extension.mjs unchanged; new `bin` is additive**
+
+**Decision:**
+
+- `extension.mjs` is **not modified** by this PR. Existing Copilot CLI
+  users see no behavioural change.
+- `bin/install.mjs` and `bin/setup.mjs` are **not modified**. They keep
+  installing the Copilot CLI extension exactly as before.
+- The MCP server is exposed only via the new `bin` entry
+  (`copilot-brag-sheet-mcp`). Hosts opt in by configuring it as an MCP
+  server (e.g. `claude mcp add … -- npx copilot-brag-sheet-mcp`) or via
+  the Claude Code plugin manifest.
+
+**Why:**
+
+- Surgical changes only. Touching install scripts to "auto-detect engine"
+  is a separate, riskier feature that needs its own design discussion
+  (what does "detect" mean? what about machines with multiple engines?).
+- Keeping the two entry points cleanly separated means a regression in
+  one path can't take down the other.
+
+**Follow-up:** A future PR can teach `install.ps1` / `install.sh` to also
+register the MCP server with Claude Code / Codex / Cursor when those CLIs
+are detected on `$PATH`. Out of scope here.
+
+---
+
+## 5. Version → **v1.1.0 (additive, not breaking)**
+
+**Decision:** When this work ships, bump to **`1.1.0`**. The version bump
+itself is **not done in this PR** — that's a separate decision tied to
+release timing.
+
+**Why `1.1.0`:**
+
+- Pure addition: new `bin` entry, new optional manifest, no change to
+  existing exports, install behaviour, or data layout.
+- Existing users who do `npm i -g copilot-brag-sheet` get the new
+  `copilot-brag-sheet-mcp` binary alongside the old one — no migration
+  required.
+- SemVer minor is the textbook fit ("backwards-compatible functionality
+  added").
+
+**Why v2.0.0 was rejected:** A major bump signals breaking changes; there
+are none. Reserving v2 for the hooks/auto-tracking work (question 2)
+keeps the version line meaningful.
+
+[issue #22]: https://github.com/microsoft/copilot-brag-sheet/issues/22

--- a/docs/cross-engine-decisions.md
+++ b/docs/cross-engine-decisions.md
@@ -10,26 +10,39 @@ Reusable" sections of the parent spec stand unchanged.
 
 ---
 
-## 1. Zero-dep vs SDK → **zero-dep, hand-roll JSON-RPC**
+## 1. Zero-dep vs SDK → **use the official MCP SDK + Zod**
 
-**Decision:** Implement MCP over stdio by hand. Do **not** add
-`@modelcontextprotocol/sdk` (or any other runtime dep) to `package.json`.
+**Decision:** Build the MCP server on `@modelcontextprotocol/sdk` with
+`zod` for input schemas. Declare both as runtime dependencies in
+`package.json`. The brand surface flips from "zero dependencies" to
+"MCP-conformant".
 
 **Why:**
 
-- The package's brand promise ("Zero dependencies, local-first") is in the
-  README, the npm description, the SKILL.md, and the marketplace
-  submissions. Breaking it for a transport shim is a bad trade.
-- The MCP wire protocol we need is small: `initialize`, `tools/list`,
-  `tools/call`, `ping`, plus newline-delimited JSON framing. ~50 lines of
-  hand-rolled code vs a transitive dep tree.
-- All real work (storage, render, git backup) already lives in `lib/` —
-  the SDK would only manage the transport, which is the easy part.
+- Conformance beats independence. The SDK validates handshake versions,
+  reserved JSON-RPC ids, capability negotiation, and content-type
+  envelopes for free. Hand-rolling these would diverge from the spec
+  every time the spec moves.
+- Zod gives us strict input schemas (`.strict()` → JSON Schema
+  `additionalProperties: false`), declarative `outputSchema` for every
+  tool, and parse errors that surface as proper `-32602` results rather
+  than ad-hoc strings. Both are required by the MCP protocol's reference
+  implementation guidance the parent spec cites.
+- Two deps is still a small surface. Both are widely audited, ship ESM,
+  and pin to caret ranges. The original "zero dependency" goal protected
+  install-time UX; with `npm install` already required for the extension,
+  two transitive trees do not change the install story meaningfully.
+- Enables the 10-question evaluation suite at `evals/` to run against the
+  same wire surface real MCP hosts will use, with no protocol drift
+  between local tests and downstream consumers.
 
-**Cost:** We own the framing/dispatch code. If MCP adds new required
-features (e.g. resources, prompts, sampling), we update one file.
+**Cost:** Two runtime deps (`@modelcontextprotocol/sdk`, `zod`). Brand
+copy in README / SKILL / plugin manifests had to flip. The tradeoff is
+explicit: we accept dependencies in exchange for spec conformance and a
+thinner server file.
 
-**File:** [`mcp-server.mjs`](../mcp-server.mjs) at repo root.
+**File:** [`mcp-server.mjs`](../mcp-server.mjs) at repo root, with the
+matching evaluation suite at [`evals/`](../evals/).
 
 ---
 

--- a/docs/cross-engine-spec.md
+++ b/docs/cross-engine-spec.md
@@ -115,7 +115,7 @@ npx copilot-brag-sheet mcp-server
 
 ## What's Reusable (90% of code)
 
-All 6 lib modules are pure Node.js with zero dependencies:
+All 6 lib modules stay pure Node.js with no runtime dependencies (only the MCP server adds `@modelcontextprotocol/sdk` + `zod`):
 - `lib/paths.mjs` — data dir detection (OS-specific app-data)
 - `lib/config.mjs` — presets (microsoft, default), categories, user context
 - `lib/storage.mjs` — JSON record I/O (atomic writes, crash recovery)
@@ -125,9 +125,9 @@ All 6 lib modules are pure Node.js with zero dependencies:
 
 ## What Needs Building
 
-### 1. MCP Server (`mcp-server.mjs`) — ~100-150 lines
-- Import `@modelcontextprotocol/sdk` (or hand-roll JSON-RPC — it's simple)
-- Register 3 tools with JSON schemas matching current extension tool signatures
+### 1. MCP Server (`mcp-server.mjs`) — ~400-450 lines
+- Built on `@modelcontextprotocol/sdk` with `zod` for strict input schemas
+- Register 3 tools (camelCase output schemas, tool annotations, response_format)
 - Each tool handler calls into lib/ modules
 - Stdio transport (stdin/stdout)
 
@@ -143,11 +143,11 @@ All 6 lib modules are pure Node.js with zero dependencies:
 
 ### 4. Package.json Updates
 - Add `"mcp-server"` to `bin` field for npx distribution
-- Possibly add `@modelcontextprotocol/sdk` as optional dep (or keep zero-dep and hand-roll)
+- Add `@modelcontextprotocol/sdk` and `zod` as runtime deps (decided in [decisions doc](./cross-engine-decisions.md#1-zero-dep-vs-sdk--use-the-official-mcp-sdk--zod))
 
 ## Open Questions
 
-1. **Zero-dep vs SDK:** Hand-roll MCP JSON-RPC (~50 extra lines) to maintain zero-dependency promise? Or add `@modelcontextprotocol/sdk` as the first dependency?
+1. **Zero-dep vs SDK:** ✅ Resolved — adopt `@modelcontextprotocol/sdk` + `zod`. See [decisions doc](./cross-engine-decisions.md#1-zero-dep-vs-sdk--use-the-official-mcp-sdk--zod).
 2. **Hook state persistence:** Hooks run as separate processes — how to share session state between session_start and session_end? (Options: temp file, env var, PID-keyed storage)
 3. **File tracking in hooks:** Can Claude Code hooks observe file edits? Or do we only get session start/end?
 4. **Backward compat:** Should `install.ps1`/`install.sh` detect engine type and wire both extension.mjs AND MCP server?

--- a/docs/index.html
+++ b/docs/index.html
@@ -46,7 +46,7 @@
         "@type": "SoftwareApplication",
         "name": "copilot-brag-sheet",
         "alternateName": ["Copilot Brag Sheet", "brag-sheet", "Copilot CLI brag sheet"],
-        "description": "A GitHub Copilot CLI extension that auto-records your work as you go — files edited, PRs created, git actions — so performance review season has evidence instead of a blank page. Local-first, zero dependencies, zero telemetry.",
+        "description": "A GitHub Copilot CLI extension that auto-records your work as you go — files edited, PRs created, git actions — so performance review season has evidence instead of a blank page. Local-first, MCP-conformant, zero telemetry.",
         "url": "https://github.com/microsoft/copilot-brag-sheet",
         "applicationCategory": "DeveloperApplication",
         "applicationSubCategory": "CLI",
@@ -432,7 +432,7 @@
           </p>
           <p class="meta">
             <strong>🔒 Local-first</strong> &nbsp;·&nbsp;
-            <strong>📦 Zero dependencies</strong> &nbsp;·&nbsp;
+            <strong>🤝 MCP-conformant</strong> &nbsp;·&nbsp;
             <strong>🚫 Zero telemetry</strong>
           </p>
           <div class="badges">

--- a/evals/README.md
+++ b/evals/README.md
@@ -1,0 +1,65 @@
+# MCP Eval Suite — copilot-brag-sheet
+
+This directory holds the 10-question evaluation suite that exercises the
+`brag-sheet-mcp-server` MCP server end-to-end against a deterministic fixture.
+
+## Files
+
+| File | Purpose |
+| --- | --- |
+| `fixtures/entries.json` | 15 brag-sheet entries with relative-day timestamps. Stable summaries / tags / impact / repos so the LLM can locate any entry by exact text. |
+| `seed.mjs` | Wipes a target data directory and seeds it with the fixture using the same `writeRecord` path the live server uses. |
+| `brag-sheet.eval.xml` | 10 `<qa_pair>` evaluation questions following the MCP protocol's evaluation format: closed-window, independent, complex, single deterministic answer, fixture-derived. |
+
+## Running locally
+
+1. Install deps and verify the server is healthy:
+   ```bash
+   npm install
+   npm test
+   ```
+
+2. Seed the fixture into a scratch directory:
+   ```bash
+   WORK_TRACKER_DIR=$(mktemp -d) node evals/seed.mjs
+   ```
+   On Windows PowerShell:
+   ```powershell
+   $env:WORK_TRACKER_DIR = (New-Item -ItemType Directory -Path "$env:TEMP\bs-eval-$(Get-Random)").FullName
+   node evals/seed.mjs
+   ```
+
+3. Point your MCP eval harness at `evals/brag-sheet.eval.xml`. Make sure it
+   spawns the server with the same `WORK_TRACKER_DIR` so the fixture is
+   visible:
+   ```bash
+   WORK_TRACKER_DIR="$WORK_TRACKER_DIR" mcp-eval evals/brag-sheet.eval.xml \
+     --server "node $(pwd)/mcp-server.mjs"
+   ```
+
+## Fixture timing model
+
+Each fixture entry stores a `daysAgo` field. At seed time we compute
+`timestamp = now - daysAgo * 86400000` so the dataset's relative recency is
+identical regardless of when the suite is run. The seed clears the target
+directory first so re-runs are idempotent.
+
+| Window | Entry count | Coverage |
+| --- | --- | --- |
+| `weeks=1` (last 7 d) | 3 | days-ago: 2, 4, 6 |
+| `weeks=4` (last 28 d) | 9 | days-ago: 2, 4, 6, 8, 10, 14, 18, 22, 26 (30-day entry falls just outside the window) |
+| `weeks=12` (last 84 d) | 15 | all entries |
+
+## Question design notes
+
+The 10 questions cover the full surface of the server's three tools:
+
+- **save_to_brag_sheet** is exercised in Q9 (round-trip) and Q10 (invalid
+  category error path).
+- **review_brag_sheet** is the workhorse — used in Q2–Q8 and Q9 — with windows
+  ranging from 7 d to 84 d so the LLM has to reason about the time filter.
+- **generate_work_log** is exercised in Q1 (full count).
+
+Each expected answer is a single deterministic token (number, exact summary
+string, repo name, category id, CVE id) so an MCP eval harness can score
+with simple substring or trim-equals matching.

--- a/evals/brag-sheet.eval.xml
+++ b/evals/brag-sheet.eval.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Evaluation suite for the brag-sheet-mcp-server.
+
+  Per the MCP protocol's evaluation guidance, each question is:
+    - read-only / non-destructive / idempotent (with one save_to_brag_sheet
+      round-trip in q9 to verify the write path)
+    - independent — answering one question never reveals another's answer
+    - complex enough to require multiple tool calls or careful filtering
+    - answerable by a single, verifiable value via direct string comparison
+    - derivable from the seeded fixture (evals/fixtures/entries.json)
+
+  Setup before running an eval harness:
+    WORK_TRACKER_DIR=$(mktemp -d) node evals/seed.mjs
+    # then run the harness with the same WORK_TRACKER_DIR
+
+  Total: 10 qa_pairs.
+-->
+<evaluation>
+  <qa_pair>
+    <question>Generate the full work log to a temporary path of your choosing and report the total number of records that were written. Reply with only the number.</question>
+    <answer>15</answer>
+  </qa_pair>
+  <qa_pair>
+    <question>Use review_brag_sheet with weeks=1 and a limit large enough that nothing is paginated out. How many records does the response report inside that 7-day window? Reply with only the number.</question>
+    <answer>3</answer>
+  </qa_pair>
+  <qa_pair>
+    <question>Use review_brag_sheet with weeks=4 and a limit large enough that nothing is paginated out. How many records does the response report inside that 28-day window? Reply with only the number.</question>
+    <answer>9</answer>
+  </qa_pair>
+  <qa_pair>
+    <question>Use review_brag_sheet with weeks=12 and request enough pages to see every record. One record is tagged "kubernetes-rotation". What is the exact summary text of that record? Reply with only the summary, no quotes, no extra prose.</question>
+    <answer>Built the kubernetes-rotation CLI that batches AKS upgrades across 38 clusters with progressive rollout safeguards</answer>
+  </qa_pair>
+  <qa_pair>
+    <question>Use review_brag_sheet with weeks=12 and request enough pages to see every record. Which repo is associated with the record tagged "rate-limiter"? Reply with only the repo name.</question>
+    <answer>rate-limiter-sdk</answer>
+  </qa_pair>
+  <qa_pair>
+    <question>Use review_brag_sheet with weeks=12 and request enough pages to see every record. Which record has the impact line "184k USD per year savings; 99.99 percent ingestion SLA"? Reply with the exact category id of that record.</question>
+    <answer>infrastructure</answer>
+  </qa_pair>
+  <qa_pair>
+    <question>Use review_brag_sheet with weeks=12 and request enough pages to see every record. How many records belong to the "investigation" category? Reply with only the number.</question>
+    <answer>2</answer>
+  </qa_pair>
+  <qa_pair>
+    <question>Use review_brag_sheet with weeks=12 and request enough pages to see every record. One of the records patches a CVE before public disclosure. What is the exact CVE id mentioned in that record's summary? Reply with only the CVE id.</question>
+    <answer>CVE-2024-77777</answer>
+  </qa_pair>
+  <qa_pair>
+    <question>Call save_to_brag_sheet with summary="eval-marker-alpha-77" and category="documentation". Then use review_brag_sheet with weeks=1 and a large enough limit to see every record. How many records does the response report? Reply with only the number.</question>
+    <answer>4</answer>
+  </qa_pair>
+  <qa_pair>
+    <question>Call save_to_brag_sheet with arguments {"summary":"eval-uuid-probe","category":"definitely-not-a-category"}. The tool result will have isError=true. Read the error text. Which valid category id begins with the letter "p" appears in the list of valid categories? Reply with only that category id.</question>
+    <answer>pr</answer>
+  </qa_pair>
+</evaluation>

--- a/evals/fixtures/entries.json
+++ b/evals/fixtures/entries.json
@@ -1,0 +1,141 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema#",
+  "description": "Deterministic seed entries for the brag-sheet MCP eval suite. Each entry's timestamp is computed at seed time as (now - daysAgo*86400000). Tags and summaries are unique so the eval LLM can locate any entry by exact text.",
+  "entries": [
+    {
+      "daysAgo": 2,
+      "summary": "Shipped the rust-based query planner that cut p95 latency from 480 ms to 96 ms across 12 tenants",
+      "category": "pr",
+      "tags": ["rust", "query-planner", "latency"],
+      "impact": "p95 latency 480 ms -> 96 ms across 12 tenants",
+      "repo": "infra-query-planner",
+      "branch": "feat/rust-planner"
+    },
+    {
+      "daysAgo": 4,
+      "summary": "Investigated and root-caused the cascading retry storm in the payments gateway during the 2025-Q1 incident",
+      "category": "investigation",
+      "tags": ["payments", "incident", "retry-storm"],
+      "impact": "RCA published; circuit breaker pattern adopted by 4 partner teams",
+      "repo": "payments-gateway",
+      "branch": "main"
+    },
+    {
+      "daysAgo": 6,
+      "summary": "Authored the design doc for the cross-region failover automation that replaced 14 hours of manual runbooks",
+      "category": "design",
+      "tags": ["failover", "automation", "design-doc"],
+      "impact": "14 manual runbook hours per region rotation -> 6 minutes",
+      "repo": "ops-failover",
+      "branch": "design/cross-region"
+    },
+    {
+      "daysAgo": 8,
+      "summary": "Built the kubernetes-rotation CLI that batches AKS upgrades across 38 clusters with progressive rollout safeguards",
+      "category": "tooling",
+      "tags": ["kubernetes-rotation", "aks", "cli"],
+      "impact": "AKS upgrade time 9 days -> 38 hours; zero customer-impacting incidents",
+      "repo": "k8s-rotation-cli",
+      "branch": "main"
+    },
+    {
+      "daysAgo": 10,
+      "summary": "Fixed the off-by-one bug in the leader-election timer that caused split-brain on 3 production clusters",
+      "category": "bugfix",
+      "tags": ["leader-election", "split-brain", "consensus"],
+      "impact": "Eliminated 3 recurring SEV2 incidents/month",
+      "repo": "consensus-core",
+      "branch": "fix/leader-election-timer"
+    },
+    {
+      "daysAgo": 14,
+      "summary": "Drove the cross-org migration from EOL TLS 1.1 to TLS 1.3 across 47 services on schedule",
+      "category": "collaboration",
+      "tags": ["tls", "migration", "security"],
+      "impact": "47/47 services migrated; closed an SDL audit finding",
+      "repo": "tls-migration",
+      "branch": "main"
+    },
+    {
+      "daysAgo": 18,
+      "summary": "Mentored two new engineers through their first on-call rotation; both passed the post-rotation review",
+      "category": "collaboration",
+      "tags": ["mentoring", "oncall", "team"],
+      "impact": "On-call confidence survey jumped from 3.1 to 4.4 / 5",
+      "repo": "team-handbook",
+      "branch": "main"
+    },
+    {
+      "daysAgo": 22,
+      "summary": "Held the on-call beeper for the long-tail platform rotation and resolved 9 pages with 100 percent SLO compliance",
+      "category": "oncall",
+      "tags": ["oncall", "platform", "slo"],
+      "impact": "9 pages, 9 mitigations, 0 SLO breaches across the week",
+      "repo": "platform-oncall",
+      "branch": "main"
+    },
+    {
+      "daysAgo": 26,
+      "summary": "Rewrote the documentation for the multi-tenant rate-limiter SDK and reduced support tickets by 62 percent",
+      "category": "documentation",
+      "tags": ["docs", "rate-limiter", "sdk"],
+      "impact": "Support ticket volume down 62 percent month over month",
+      "repo": "rate-limiter-sdk",
+      "branch": "docs/rewrite"
+    },
+    {
+      "daysAgo": 30,
+      "summary": "Stood up the new observability pipeline that replaced 3 legacy collectors and saved 184k USD per year",
+      "category": "infrastructure",
+      "tags": ["observability", "cost", "pipeline"],
+      "impact": "184k USD per year savings; 99.99 percent ingestion SLA",
+      "repo": "observability-pipeline",
+      "branch": "main"
+    },
+    {
+      "daysAgo": 38,
+      "summary": "Refactored the auth middleware to remove the global mutex that was throttling sign-in throughput",
+      "category": "pr",
+      "tags": ["auth", "middleware", "performance"],
+      "impact": "Sign-in throughput 1.2k -> 14.5k req/s on the same hardware",
+      "repo": "auth-svc",
+      "branch": "refactor/remove-global-mutex"
+    },
+    {
+      "daysAgo": 45,
+      "summary": "Investigated a memory leak in the streaming compactor that surfaced only after 96 hours of uptime",
+      "category": "investigation",
+      "tags": ["memory-leak", "compactor", "longevity"],
+      "impact": "Compactor RSS plateaus at 1.6 GB instead of OOM-killing daily",
+      "repo": "stream-compactor",
+      "branch": "main"
+    },
+    {
+      "daysAgo": 52,
+      "summary": "Designed and shipped the schema-registry-v2 migration tool that handled 11k schemas without manual intervention",
+      "category": "tooling",
+      "tags": ["schema-registry", "migration", "tooling"],
+      "impact": "11k schemas migrated; 0 production incidents",
+      "repo": "schema-registry-v2",
+      "branch": "feat/migration-tool"
+    },
+    {
+      "daysAgo": 58,
+      "summary": "Patched a CVE-2024-77777 RCE vector in the websocket handshake parser before public disclosure",
+      "category": "bugfix",
+      "tags": ["cve", "security", "websocket"],
+      "impact": "Pre-disclosure patch shipped to 100 percent of the fleet",
+      "repo": "ws-gateway",
+      "branch": "security/cve-2024-77777"
+    },
+    {
+      "daysAgo": 60,
+      "summary": "Drafted the architecture review for the new chaos-engineering harness used by all 6 platform pods",
+      "category": "design",
+      "tags": ["chaos", "architecture", "review"],
+      "impact": "Harness adopted by all 6 platform pods this quarter",
+      "repo": "chaos-harness",
+      "branch": "design/v1"
+    }
+  ]
+}

--- a/evals/seed.mjs
+++ b/evals/seed.mjs
@@ -1,0 +1,66 @@
+#!/usr/bin/env node
+/**
+ * @fileoverview Seed deterministic brag-sheet entries for the MCP eval suite.
+ *
+ * Reads `evals/fixtures/entries.json`, computes a real timestamp for each entry
+ * from its `daysAgo` offset, and writes the records into the data directory
+ * specified by `WORK_TRACKER_DIR` (or the first CLI arg) using the same
+ * `writeRecord` codepath the live server uses. The directory is wiped clean
+ * first so reseeding produces a byte-identical state every run.
+ *
+ * Usage:
+ *   WORK_TRACKER_DIR=/tmp/eval node evals/seed.mjs
+ *   node evals/seed.mjs /tmp/eval
+ *
+ * After seeding, point the eval harness at the same WORK_TRACKER_DIR and run
+ * `evals/brag-sheet.eval.xml`.
+ */
+
+import { readFileSync, rmSync, mkdirSync, existsSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { randomUUID } from "node:crypto";
+
+import { writeRecord } from "../lib/storage.mjs";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+const dataDir = process.env.WORK_TRACKER_DIR || process.argv[2];
+if (!dataDir) {
+  process.stderr.write(
+    "[seed] missing target directory; pass WORK_TRACKER_DIR or argv[2]\n",
+  );
+  process.exit(1);
+}
+
+if (existsSync(dataDir)) {
+  rmSync(dataDir, { recursive: true, force: true });
+}
+mkdirSync(dataDir, { recursive: true });
+
+const fixturePath = join(__dirname, "fixtures", "entries.json");
+const fixture = JSON.parse(readFileSync(fixturePath, "utf8"));
+
+const now = Date.now();
+let written = 0;
+
+for (const item of fixture.entries) {
+  const timestamp = new Date(now - item.daysAgo * 86400000).toISOString();
+  const entry = {
+    id: randomUUID(),
+    type: "entry",
+    source: "manual",
+    timestamp,
+    summary: item.summary,
+    category: item.category,
+    tags: item.tags ?? [],
+    impact: item.impact ?? null,
+    repo: item.repo ?? null,
+    branch: item.branch ?? null,
+    sessionId: null,
+  };
+  writeRecord(dataDir, entry);
+  written += 1;
+}
+
+process.stdout.write(`[seed] wrote ${written} entries to ${dataDir}\n`);

--- a/extension.mjs
+++ b/extension.mjs
@@ -3,7 +3,7 @@
  *
  * Automatically tracks Copilot CLI sessions into structured JSON records
  * and provides tools for maintaining a personal work impact log.
- * Zero dependencies, cross-platform (Windows/macOS/Linux), Node 18+.
+ * Local-first, cross-platform (Windows/macOS/Linux), Node 18+.
  *
  * @license MIT
  * @see https://github.com/microsoft/copilot-brag-sheet

--- a/mcp-server.mjs
+++ b/mcp-server.mjs
@@ -217,8 +217,13 @@ const ReviewOutputSchema = z.object({
 
 const GenerateInputSchema = z.object({
   outputPath: z.string()
+    .refine((p) => path.isAbsolute(p), {
+      message: "outputPath must be an absolute path (got a relative path)",
+    })
     .optional()
-    .describe("Absolute path of the markdown file to write. Defaults to work-log.md inside the data directory."),
+    .describe(
+      "Absolute path of the markdown file to write. Must be absolute — relative paths are rejected to prevent accidentally clobbering files in the host's working directory. Defaults to work-log.md inside the data directory.",
+    ),
   response_format: ResponseFormatSchema,
 }).strict();
 

--- a/mcp-server.mjs
+++ b/mcp-server.mjs
@@ -1,32 +1,41 @@
 /**
  * @fileoverview Copilot Brag Sheet — MCP Server (cross-engine)
  *
- * Hand-rolled stdio JSON-RPC 2.0 server implementing the Model Context
- * Protocol (MCP). Exposes the same three tools as the Copilot CLI extension
- * (save_to_brag_sheet, review_brag_sheet, generate_work_log) so any
- * MCP-compatible host (Claude Code, Codex CLI, VS Code, Agency, Cursor) can
- * use the brag sheet without the Copilot-specific joinSession() API.
+ * Stdio MCP server built on the official MCP TypeScript SDK
+ * (`@modelcontextprotocol/sdk`) with Zod-validated `inputSchema` /
+ * `outputSchema` and MCP tool annotations.
  *
- * Protocol references:
- *   - MCP spec:   https://modelcontextprotocol.io/specification/2025-06-18
- *   - JSON-RPC 2: https://www.jsonrpc.org/specification
+ * Exposes the same three tools as the Copilot CLI extension —
+ * `save_to_brag_sheet`, `review_brag_sheet`, and `generate_work_log` — to
+ * any MCP host over stdio.
  *
  * Design notes:
- *   - Zero runtime dependencies (preserves the package's brand promise).
- *   - extension.mjs is left untouched; this module is purely additive.
- *   - All real work is delegated to the existing lib/* modules — this file
- *     is just a transport/protocol shim.
- *   - All logs go to stderr; stdout is reserved for JSON-RPC frames.
+ *   - The SDK owns JSON-RPC framing, dispatch, validation, and capability
+ *     negotiation. This module only registers tools and delegates to the
+ *     existing `lib/*` modules.
+ *   - Every tool declares an `outputSchema`; every tool returns
+ *     `structuredContent` whose shape matches that schema, plus a text
+ *     payload formatted per the requested `response_format`.
+ *   - Tool annotations advertise behaviour (read-only / destructive /
+ *     idempotent / open-world) so MCP hosts can render confirmation UI.
+ *   - Stdout is reserved for JSON-RPC frames (the SDK's StdioServerTransport
+ *     handles that). Logs go to stderr.
  *
  * @license MIT
  * @see https://github.com/microsoft/copilot-brag-sheet
+ * @see https://modelcontextprotocol.io/specification
  */
 
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 import {
   openSync, closeSync, writeFileSync, fsyncSync,
-  renameSync, unlinkSync,
+  renameSync, unlinkSync, readFileSync, statSync,
 } from "node:fs";
+
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { z } from "zod";
 
 import { detectDataDir, detectBragSheetPath, detectGitConfig, ensureDir } from "./lib/paths.mjs";
 import { loadConfig, getAllCategoryIds, isValidCategory } from "./lib/config.mjs";
@@ -35,24 +44,31 @@ import { backupToGit } from "./lib/git-backup.mjs";
 import { createEntryRecord } from "./lib/records.mjs";
 import { renderMarkdown, renderReviewSummary } from "./lib/render.mjs";
 
-// Read package.json once at startup for the server version reported in
-// the initialize handshake. Best-effort — fall back to "unknown".
-import { readFileSync } from "node:fs";
-import { fileURLToPath } from "node:url";
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+// Server name follows the Node MCP convention `{service}-mcp-server`
+// documented in the MCP best-practices reference.
+const SERVER_NAME = "brag-sheet-mcp-server";
+
+// Cap rendered markdown in the response. Hosts forward tool output into LLM
+// context and a runaway brag sheet would burn through it.
+const CHARACTER_LIMIT = 25000;
+
+// Default page size for `review_brag_sheet`. Aligned with the 20–50 range
+// recommended in the MCP best-practices reference.
+const DEFAULT_REVIEW_LIMIT = 20;
+const MAX_REVIEW_LIMIT = 100;
+
 let SERVER_VERSION = "unknown";
 try {
   const pkg = JSON.parse(readFileSync(path.join(__dirname, "package.json"), "utf8"));
   SERVER_VERSION = pkg.version || "unknown";
 } catch { /* best effort */ }
 
-const SERVER_NAME = "copilot-brag-sheet";
-const PROTOCOL_VERSION = "2025-06-18";
-
 // ── Lazy state ──────────────────────────────────────────────────────────────
 // Initialised on first tool call so the initialize handshake is fast and so
-// errors surface in tool responses (where the host can show them) rather
-// than at module load time.
+// detection errors surface in the model's view of the tool result rather
+// than as opaque transport errors at startup.
 
 let dataDir = null;
 let config = null;
@@ -91,74 +107,177 @@ function atomicWriteText(filePath, text) {
   }
 }
 
-// ── Tool definitions ────────────────────────────────────────────────────────
-// Schemas and descriptions kept in sync with extension.mjs so any host gets
-// the same tool surface regardless of how the package is loaded.
+function truncateMarkdown(markdown) {
+  if (typeof markdown !== "string" || markdown.length <= CHARACTER_LIMIT) {
+    return { markdown, truncated: false };
+  }
+  const slice = markdown.slice(0, CHARACTER_LIMIT);
+  const note = `\n\n_…truncated to ${CHARACTER_LIMIT} chars. Narrow the window with the \`weeks\` parameter or use \`limit\`/\`offset\` to page._`;
+  return { markdown: slice + note, truncated: true };
+}
 
-const TOOLS = [
-  {
-    name: "save_to_brag_sheet",
-    description: [
-      "Save a work entry to the user's brag sheet / work impact log.",
-      "Also known as: save work entry, log accomplishment, record impact.",
-      "Use for significant accomplishments: PRs, bug fixes, design docs, on-call wins.",
-      "Format summary as impact-first: 'Did X for Y → Result Z → Evidence'.",
-      "Valid categories: pr, bugfix, infrastructure, investigation, collaboration, tooling, oncall, design, documentation.",
-    ].join(" "),
-    inputSchema: {
-      type: "object",
-      properties: {
-        summary: { type: "string", description: "Impact-first summary of what was accomplished" },
-        category: { type: "string", description: "Category of work" },
-        impact: { type: "string", description: "Who/what benefited and how (metrics if possible)" },
-        tags: { type: "array", items: { type: "string" }, description: "Tags for filtering" },
-        repo: { type: "string", description: "Repository name (auto-detected if omitted)" },
-        branch: { type: "string", description: "Branch name (auto-detected if omitted)" },
-      },
-      required: ["summary"],
-    },
-  },
-  {
-    name: "review_brag_sheet",
-    description:
-      "Read recent entries from the user's brag sheet / work impact log. "
-      + "Also known as: review work log, show recent work, summarize accomplishments. "
-      + "Use to review, refine, or summarize work for performance reviews or manager discussions.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        weeks: { type: "number", description: "Number of recent weeks to show (default: 4)" },
-      },
-    },
-  },
-  {
-    name: "generate_work_log",
-    description: "Generate a complete work log markdown file from all records. Writes to disk.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        outputPath: {
-          type: "string",
-          description: "Output file path (defaults to work-log.md in data directory)",
-        },
-      },
-    },
-  },
-];
+function toolText(text, structuredContent) {
+  const result = { content: [{ type: "text", text }] };
+  if (structuredContent !== undefined) {
+    result.structuredContent = structuredContent;
+  }
+  return result;
+}
+
+function toolError(message, structuredContent) {
+  const result = {
+    content: [{ type: "text", text: `Error: ${message}` }],
+    isError: true,
+  };
+  if (structuredContent !== undefined) {
+    result.structuredContent = structuredContent;
+  }
+  return result;
+}
+
+// ── Schemas ─────────────────────────────────────────────────────────────────
+
+const ResponseFormatSchema = z.enum(["markdown", "json"])
+  .default("markdown")
+  .describe("Output format. 'markdown' is human-readable; 'json' is the raw structured envelope.");
+
+const SaveInputSchema = z.object({
+  summary: z.string()
+    .min(1, "summary is required and cannot be empty")
+    .max(500, "summary must not exceed 500 characters")
+    .describe("Impact-first summary of what was accomplished. Format: 'Did X for Y → Result Z → Evidence'."),
+  category: z.string()
+    .optional()
+    .describe("Category id, e.g. 'pr', 'bugfix', 'infrastructure', 'investigation', 'collaboration', 'tooling', 'oncall', 'design', 'documentation'."),
+  impact: z.string()
+    .optional()
+    .describe("Who or what benefited and how. Include metrics if possible (e.g. 'cut latency 40%', '8 partner teams unblocked')."),
+  tags: z.array(z.string())
+    .optional()
+    .describe("Free-form tags for filtering later (e.g. ['mcp','migration'])."),
+  repo: z.string()
+    .optional()
+    .describe("Repository name. Auto-detected from git context when omitted."),
+  branch: z.string()
+    .optional()
+    .describe("Git branch name. Auto-detected from git context when omitted."),
+  response_format: ResponseFormatSchema,
+}).strict();
+
+const SaveOutputSchema = z.object({
+  success: z.boolean().describe("Whether the entry was persisted to disk."),
+  entryId: z.string().describe("UUID of the saved entry."),
+  category: z.string().nullable().describe("Resolved category id, or null when none was provided."),
+  summary: z.string().describe("Sanitized summary actually persisted (newlines stripped, capped to 500 chars)."),
+  timestamp: z.string().describe("ISO-8601 timestamp the entry was created at."),
+});
+
+const ReviewInputSchema = z.object({
+  weeks: z.number()
+    .int("weeks must be a whole number")
+    .min(1, "weeks must be at least 1")
+    .max(104, "weeks must not exceed 104 (2 years)")
+    .default(4)
+    .describe("Lookback window in weeks. Entries older than now() - weeks*7d are excluded."),
+  limit: z.number()
+    .int()
+    .min(1)
+    .max(MAX_REVIEW_LIMIT)
+    .default(DEFAULT_REVIEW_LIMIT)
+    .describe(`Maximum number of records to return in this page (1–${MAX_REVIEW_LIMIT}, default ${DEFAULT_REVIEW_LIMIT}).`),
+  offset: z.number()
+    .int()
+    .min(0)
+    .default(0)
+    .describe("Number of records to skip for pagination (default 0)."),
+  response_format: ResponseFormatSchema,
+}).strict();
+
+const ReviewItemSchema = z.object({
+  id: z.string().describe("Record UUID."),
+  type: z.string().describe("Record kind, e.g. 'entry' or 'session'."),
+  timestamp: z.string().describe("ISO-8601 timestamp of the record."),
+  summary: z.string().nullable().describe("Summary text, or null for sessions without one."),
+  category: z.string().nullable().describe("Category id, or null."),
+  tags: z.array(z.string()).describe("Record tags."),
+  impact: z.string().nullable().describe("Impact line, or null."),
+  repo: z.string().nullable().describe("Repository name, or null."),
+  branch: z.string().nullable().describe("Branch name, or null."),
+});
+
+const ReviewOutputSchema = z.object({
+  total: z.number().describe("Total records inside the lookback window, before pagination."),
+  count: z.number().describe("Number of records in this page."),
+  offset: z.number().describe("Pagination offset that was applied."),
+  hasMore: z.boolean().describe("True when more records are available beyond this page."),
+  nextOffset: z.number().nullable().describe("Offset to request next, or null when there is no further page."),
+  weeksCovered: z.number().describe("The lookback window size that was applied, in weeks."),
+  items: z.array(ReviewItemSchema).describe("The records in this page, newest first."),
+});
+
+const GenerateInputSchema = z.object({
+  outputPath: z.string()
+    .optional()
+    .describe("Absolute path of the markdown file to write. Defaults to work-log.md inside the data directory."),
+  response_format: ResponseFormatSchema,
+}).strict();
+
+const GenerateOutputSchema = z.object({
+  success: z.boolean().describe("Whether the file was written successfully."),
+  outputPath: z.string().describe("Absolute path of the file that was written."),
+  recordCount: z.number().describe("Number of records included in the generated work log."),
+  bytesWritten: z.number().describe("Size of the written file in bytes."),
+});
+
+// ── Render helpers ──────────────────────────────────────────────────────────
+
+function recordToItem(record) {
+  return {
+    id: record.id,
+    type: record.type ?? "entry",
+    timestamp: record.timestamp,
+    summary: record.summary ?? null,
+    category: record.category ?? null,
+    tags: Array.isArray(record.tags) ? record.tags : [],
+    impact: record.impact ?? null,
+    repo: record.repo ?? null,
+    branch: record.branch ?? null,
+  };
+}
+
+function renderSavedMarkdown(entry) {
+  const label = entry.category ? ` [${entry.category}]` : "";
+  return `✅ Entry saved to brag sheet${label}: "${entry.summary}"`;
+}
+
+function renderReviewMarkdown({ records, weeks, total, offset, hasMore }) {
+  const rendered = renderReviewSummary(records, { weeks, config });
+  const body = rendered || "No entries found for the requested period.";
+  const prefix = config?.preset === "microsoft"
+    ? "_Formatted for Connect review. Use impact framing: Did X → Result Y → Evidence Z._\n\n"
+    : "";
+  const pageNote = `\n\n_Showing ${records.length} of ${total} record(s) in the last ${weeks} week(s) (offset=${offset}${hasMore ? `, more available — request offset=${offset + records.length}` : ""})._`;
+  const fullText = `${prefix}${body}${pageNote}`;
+  return truncateMarkdown(fullText);
+}
 
 // ── Tool handlers ───────────────────────────────────────────────────────────
-// Each handler returns an MCP tool result: { content: [{type:"text",text}], isError? }
 
 async function handleSaveToBragSheet(args) {
   ensureInitialized();
 
-  if (!args?.summary || !String(args.summary).trim()) {
-    return toolError("summary is required and cannot be empty");
-  }
-
   if (args.category && !isValidCategory(config, args.category)) {
     const valid = getAllCategoryIds(config).join(", ");
-    return toolError(`invalid category "${args.category}". Valid: ${valid}`);
+    return toolError(
+      `invalid category "${args.category}". Valid: ${valid}`,
+      {
+        success: false,
+        entryId: "",
+        category: args.category,
+        summary: args.summary,
+        timestamp: new Date().toISOString(),
+      },
+    );
   }
 
   const entry = createEntryRecord({
@@ -168,31 +287,73 @@ async function handleSaveToBragSheet(args) {
     tags: Array.isArray(args.tags) ? args.tags : [],
     repo: args.repo || null,
     branch: args.branch || null,
-    sessionId: null, // MCP servers have no Copilot session context
+    sessionId: null,
   });
 
   writeRecord(dataDir, entry);
 
-  // Fire-and-forget git backup — never block tool response on network I/O.
+  // Fire-and-forget git backup — never block the tool response on network I/O.
   backupToGit({ dataDir, gitConfig }).catch(() => {});
 
-  const label = args.category ? ` [${args.category}]` : "";
-  return toolText(`✅ Entry saved to brag sheet${label}: "${entry.summary}"`);
+  const structuredContent = {
+    success: true,
+    entryId: entry.id,
+    category: entry.category,
+    summary: entry.summary,
+    timestamp: entry.timestamp,
+  };
+
+  const text = args.response_format === "json"
+    ? JSON.stringify(structuredContent, null, 2)
+    : renderSavedMarkdown(entry);
+
+  return toolText(text, structuredContent);
 }
 
 async function handleReviewBragSheet(args) {
   ensureInitialized();
 
-  const weeks = args?.weeks ?? 4;
-  const records = readRecords(dataDir, {
+  const weeks = args.weeks ?? 4;
+  const limit = args.limit ?? DEFAULT_REVIEW_LIMIT;
+  const offset = args.offset ?? 0;
+
+  const allRecords = readRecords(dataDir, {
     since: new Date(Date.now() - weeks * 7 * 86400000).toISOString(),
   });
-  const markdown = renderReviewSummary(records, { weeks, config });
-  const result = markdown || "No entries found for the requested period.";
-  const prefix = config?.preset === "microsoft"
-    ? "_Formatted for Connect review. Use impact framing: Did X → Result Y → Evidence Z._\n\n"
-    : "";
-  return toolText(`${prefix}${result}`);
+
+  // Newest first so paging mirrors how reviewers read the log.
+  allRecords.sort((a, b) => (a.timestamp < b.timestamp ? 1 : a.timestamp > b.timestamp ? -1 : 0));
+
+  const total = allRecords.length;
+  const page = allRecords.slice(offset, offset + limit);
+  const hasMore = offset + page.length < total;
+  const nextOffset = hasMore ? offset + page.length : null;
+
+  const structuredContent = {
+    total,
+    count: page.length,
+    offset,
+    hasMore,
+    nextOffset,
+    weeksCovered: weeks,
+    items: page.map(recordToItem),
+  };
+
+  let text;
+  if (args.response_format === "json") {
+    text = JSON.stringify(structuredContent, null, 2);
+  } else {
+    const { markdown } = renderReviewMarkdown({
+      records: page,
+      weeks,
+      total,
+      offset,
+      hasMore,
+    });
+    text = markdown;
+  }
+
+  return toolText(text, structuredContent);
 }
 
 async function handleGenerateWorkLog(args) {
@@ -201,157 +362,159 @@ async function handleGenerateWorkLog(args) {
   const records = readRecords(dataDir);
   const markdown = renderMarkdown(records, { config });
 
-  const outputPath = args?.outputPath || detectBragSheetPath(dataDir);
+  const outputPath = args.outputPath || detectBragSheetPath(dataDir);
   ensureDir(path.dirname(outputPath));
   atomicWriteText(outputPath, markdown);
 
   // Fire-and-forget git backup.
   backupToGit({ dataDir, gitConfig }).catch(() => {});
 
-  return toolText(`✅ Work log generated: ${outputPath} (${records.length} records)`);
+  let bytesWritten = 0;
+  try { bytesWritten = statSync(outputPath).size; } catch { /* noop */ }
+
+  const structuredContent = {
+    success: true,
+    outputPath,
+    recordCount: records.length,
+    bytesWritten,
+  };
+
+  const text = args.response_format === "json"
+    ? JSON.stringify(structuredContent, null, 2)
+    : `✅ Work log generated: ${outputPath} (${records.length} records, ${bytesWritten} bytes)`;
+
+  return toolText(text, structuredContent);
 }
 
-const HANDLERS = {
-  save_to_brag_sheet: handleSaveToBragSheet,
-  review_brag_sheet: handleReviewBragSheet,
-  generate_work_log: handleGenerateWorkLog,
-};
+// Wrap a handler so any thrown error becomes a model-visible isError result
+// instead of a transport-level error. The SDK already does Zod input
+// validation; this catches lib/* failures (disk full, permission denied, …).
+//
+// Tool calls share a single FIFO queue so a batch like
+// [save_to_brag_sheet, generate_work_log] processes deterministically — the
+// SDK dispatches messages concurrently otherwise.
+let toolQueue = Promise.resolve();
 
-function toolText(text) {
-  return { content: [{ type: "text", text }] };
-}
-
-function toolError(message) {
-  return { content: [{ type: "text", text: `Error: ${message}` }], isError: true };
-}
-
-// ── JSON-RPC dispatcher ─────────────────────────────────────────────────────
-
-async function dispatch(message) {
-  const { id, method, params } = message;
-
-  // Notifications (no `id`) — process side effects, return nothing.
-  if (id === undefined || id === null) {
-    // We don't act on any notification today; "notifications/initialized" is
-    // accepted silently so hosts that send it don't see errors.
-    return null;
-  }
-
-  switch (method) {
-    case "initialize": {
-      return rpcResult(id, {
-        protocolVersion: PROTOCOL_VERSION,
-        capabilities: { tools: {} },
-        serverInfo: { name: SERVER_NAME, version: SERVER_VERSION },
-      });
-    }
-    case "tools/list": {
-      return rpcResult(id, { tools: TOOLS });
-    }
-    case "tools/call": {
-      const name = params?.name;
-      const args = params?.arguments || {};
-      const handler = HANDLERS[name];
-      if (!handler) {
-        return rpcError(id, -32602, `Unknown tool: ${name}`);
-      }
+function safe(name, handler) {
+  return (args) => {
+    const next = toolQueue.then(async () => {
       try {
-        const result = await handler(args);
-        return rpcResult(id, result);
+        return await handler(args);
       } catch (err) {
         try { logError(dataDir || ".", `tools/call:${name}`, err); } catch { /* noop */ }
-        // MCP convention: report tool execution failures as a normal result
-        // with isError=true rather than a JSON-RPC error, so the model can
-        // see and reason about the failure.
-        return rpcResult(id, toolError(err?.message || String(err)));
+        return toolError(err?.message || String(err));
       }
-    }
-    case "ping": {
-      return rpcResult(id, {});
-    }
-    default:
-      return rpcError(id, -32601, `Method not found: ${method}`);
-  }
+    });
+    toolQueue = next.then(() => undefined, () => undefined);
+    return next;
+  };
 }
 
-function rpcResult(id, result) {
-  return { jsonrpc: "2.0", id, result };
+// ── Server registration ─────────────────────────────────────────────────────
+
+export function buildServer() {
+  const server = new McpServer({ name: SERVER_NAME, version: SERVER_VERSION });
+
+  server.registerTool(
+    "save_to_brag_sheet",
+    {
+      title: "Save brag sheet entry",
+      description: [
+        "Save a work entry to the user's brag sheet / work impact log.",
+        "Also known as: save work entry, log accomplishment, record impact.",
+        "Use for significant accomplishments: PRs, bug fixes, design docs, on-call wins.",
+        "Format the `summary` as impact-first: 'Did X for Y → Result Z → Evidence'.",
+        "Valid categories: pr, bugfix, infrastructure, investigation, collaboration, tooling, oncall, design, documentation.",
+        "Returns the saved entry id, category, sanitized summary, and timestamp in `structuredContent`.",
+        "Honors `response_format` ('markdown' for a confirmation line, 'json' for the raw envelope).",
+      ].join(" "),
+      inputSchema: SaveInputSchema,
+      outputSchema: SaveOutputSchema,
+      annotations: {
+        title: "Save brag sheet entry",
+        readOnlyHint: false,
+        destructiveHint: false,
+        idempotentHint: false,
+        openWorldHint: false,
+      },
+    },
+    safe("save_to_brag_sheet", handleSaveToBragSheet),
+  );
+
+  server.registerTool(
+    "review_brag_sheet",
+    {
+      title: "Review recent brag sheet entries",
+      description: [
+        "Read recent entries from the user's brag sheet / work impact log, paginated.",
+        "Also known as: review work log, show recent work, summarize accomplishments.",
+        "Use to review, refine, or summarize work for performance reviews or manager discussions.",
+        `Pagination: \`limit\` (1–${MAX_REVIEW_LIMIT}, default ${DEFAULT_REVIEW_LIMIT}), \`offset\` (default 0).`,
+        "`structuredContent` returns { total, count, offset, hasMore, nextOffset, weeksCovered, items }.",
+        "Honors `response_format` ('markdown' for a rendered report, 'json' for the raw envelope).",
+      ].join(" "),
+      inputSchema: ReviewInputSchema,
+      outputSchema: ReviewOutputSchema,
+      annotations: {
+        title: "Review recent brag sheet entries",
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: false,
+      },
+    },
+    safe("review_brag_sheet", handleReviewBragSheet),
+  );
+
+  server.registerTool(
+    "generate_work_log",
+    {
+      title: "Generate work log file",
+      description: [
+        "Generate a complete work log markdown file from all records and write it to disk.",
+        "Overwrites the output file atomically.",
+        "Defaults to <dataDir>/work-log.md when `outputPath` is omitted.",
+        "Returns success, absolute output path, record count, and bytes written in `structuredContent`.",
+        "Honors `response_format` ('markdown' for a confirmation line, 'json' for the raw envelope).",
+      ].join(" "),
+      inputSchema: GenerateInputSchema,
+      outputSchema: GenerateOutputSchema,
+      annotations: {
+        title: "Generate work log file",
+        readOnlyHint: false,
+        destructiveHint: true,
+        idempotentHint: true,
+        openWorldHint: false,
+      },
+    },
+    safe("generate_work_log", handleGenerateWorkLog),
+  );
+
+  return server;
 }
 
-function rpcError(id, code, message, data) {
-  const error = { code, message };
-  if (data !== undefined) error.data = data;
-  return { jsonrpc: "2.0", id, error };
-}
-
-// ── Stdio framing ───────────────────────────────────────────────────────────
-// MCP stdio transport uses newline-delimited JSON (one JSON-RPC message per
-// line). We buffer partial lines because Node may deliver chunked stdin.
+// ── Entry point ─────────────────────────────────────────────────────────────
 
 export async function runServer({ stdin = process.stdin, stdout = process.stdout } = {}) {
-  stdin.setEncoding("utf8");
+  const server = buildServer();
+  const transport = new StdioServerTransport(stdin, stdout);
+  await server.connect(transport);
 
-  let buffer = "";
-
-  const writeFrame = (msg) => {
-    if (!msg) return;
-    stdout.write(`${JSON.stringify(msg)}\n`);
-  };
-
-  const handleLine = async (line) => {
-    const trimmed = line.trim();
-    if (!trimmed) return;
-
-    let message;
-    try {
-      message = JSON.parse(trimmed);
-    } catch {
-      writeFrame(rpcError(null, -32700, "Parse error"));
-      return;
-    }
-
-    if (!message || message.jsonrpc !== "2.0") {
-      writeFrame(rpcError(message?.id ?? null, -32600, "Invalid Request"));
-      return;
-    }
-
-    try {
-      const response = await dispatch(message);
-      writeFrame(response);
-    } catch (err) {
-      writeFrame(rpcError(message.id ?? null, -32603, err?.message || "Internal error"));
-    }
-  };
-
-  return new Promise((resolve) => {
-    stdin.on("data", (chunk) => {
-      buffer += chunk;
-      let nl;
-      // Process every complete line currently in the buffer.
-      while ((nl = buffer.indexOf("\n")) !== -1) {
-        const line = buffer.slice(0, nl);
-        buffer = buffer.slice(nl + 1);
-        handleLine(line);
-      }
-    });
-    stdin.on("end", () => {
-      // Flush any trailing line without a newline.
-      if (buffer.trim()) {
-        handleLine(buffer);
-        buffer = "";
-      }
+  // The SDK keeps the event loop alive via stdin's data listener. When the
+  // peer closes stdin we let any in-flight tool calls drain (via toolQueue)
+  // before resolving so responses make it onto the wire before exit.
+  await new Promise((resolve) => {
+    const finish = async () => {
+      try { await toolQueue; } catch { /* swallowed inside safe() */ }
+      // One more microtask hop so the SDK's transport.send() promises settle.
+      await new Promise((r) => setImmediate(r));
       resolve();
-    });
-    stdin.on("error", (err) => {
-      try { logError(dataDir || ".", "stdin", err); } catch { /* noop */ }
-      resolve();
-    });
+    };
+    stdin.once?.("end", finish);
+    stdin.once?.("close", finish);
   });
 }
 
-// Auto-start when invoked as the main module (so `node mcp-server.mjs` and
-// `bin/mcp-server.mjs` both Just Work). Tests can import { runServer } and
-// drive it with their own streams.
 const isMainModule =
   process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url);
 

--- a/mcp-server.mjs
+++ b/mcp-server.mjs
@@ -1,0 +1,363 @@
+/**
+ * @fileoverview Copilot Brag Sheet — MCP Server (cross-engine)
+ *
+ * Hand-rolled stdio JSON-RPC 2.0 server implementing the Model Context
+ * Protocol (MCP). Exposes the same three tools as the Copilot CLI extension
+ * (save_to_brag_sheet, review_brag_sheet, generate_work_log) so any
+ * MCP-compatible host (Claude Code, Codex CLI, VS Code, Agency, Cursor) can
+ * use the brag sheet without the Copilot-specific joinSession() API.
+ *
+ * Protocol references:
+ *   - MCP spec:   https://modelcontextprotocol.io/specification/2025-06-18
+ *   - JSON-RPC 2: https://www.jsonrpc.org/specification
+ *
+ * Design notes:
+ *   - Zero runtime dependencies (preserves the package's brand promise).
+ *   - extension.mjs is left untouched; this module is purely additive.
+ *   - All real work is delegated to the existing lib/* modules — this file
+ *     is just a transport/protocol shim.
+ *   - All logs go to stderr; stdout is reserved for JSON-RPC frames.
+ *
+ * @license MIT
+ * @see https://github.com/microsoft/copilot-brag-sheet
+ */
+
+import path from "node:path";
+import {
+  openSync, closeSync, writeFileSync, fsyncSync,
+  renameSync, unlinkSync,
+} from "node:fs";
+
+import { detectDataDir, detectBragSheetPath, detectGitConfig, ensureDir } from "./lib/paths.mjs";
+import { loadConfig, getAllCategoryIds, isValidCategory } from "./lib/config.mjs";
+import { writeRecord, readRecords, logError } from "./lib/storage.mjs";
+import { backupToGit } from "./lib/git-backup.mjs";
+import { createEntryRecord } from "./lib/records.mjs";
+import { renderMarkdown, renderReviewSummary } from "./lib/render.mjs";
+
+// Read package.json once at startup for the server version reported in
+// the initialize handshake. Best-effort — fall back to "unknown".
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+let SERVER_VERSION = "unknown";
+try {
+  const pkg = JSON.parse(readFileSync(path.join(__dirname, "package.json"), "utf8"));
+  SERVER_VERSION = pkg.version || "unknown";
+} catch { /* best effort */ }
+
+const SERVER_NAME = "copilot-brag-sheet";
+const PROTOCOL_VERSION = "2025-06-18";
+
+// ── Lazy state ──────────────────────────────────────────────────────────────
+// Initialised on first tool call so the initialize handshake is fast and so
+// errors surface in tool responses (where the host can show them) rather
+// than at module load time.
+
+let dataDir = null;
+let config = null;
+let gitConfig = null;
+
+function ensureInitialized() {
+  if (!dataDir) {
+    dataDir = detectDataDir();
+    ensureDir(dataDir);
+  }
+  if (!config) {
+    config = loadConfig(dataDir);
+  }
+  if (!gitConfig) {
+    const envGit = detectGitConfig();
+    gitConfig = envGit.enabled ? envGit : (config?.git ?? { enabled: false, push: false });
+  }
+}
+
+function atomicWriteText(filePath, text) {
+  const tmpPath = `${filePath}.tmp.${process.pid}`;
+  let fd;
+  try {
+    fd = openSync(tmpPath, "w");
+    writeFileSync(fd, text, "utf8");
+    fsyncSync(fd);
+    closeSync(fd);
+    fd = undefined;
+    renameSync(tmpPath, filePath);
+  } catch (err) {
+    if (fd !== undefined) {
+      try { closeSync(fd); } catch { /* noop */ }
+    }
+    try { unlinkSync(tmpPath); } catch { /* noop */ }
+    throw err;
+  }
+}
+
+// ── Tool definitions ────────────────────────────────────────────────────────
+// Schemas and descriptions kept in sync with extension.mjs so any host gets
+// the same tool surface regardless of how the package is loaded.
+
+const TOOLS = [
+  {
+    name: "save_to_brag_sheet",
+    description: [
+      "Save a work entry to the user's brag sheet / work impact log.",
+      "Also known as: save work entry, log accomplishment, record impact.",
+      "Use for significant accomplishments: PRs, bug fixes, design docs, on-call wins.",
+      "Format summary as impact-first: 'Did X for Y → Result Z → Evidence'.",
+      "Valid categories: pr, bugfix, infrastructure, investigation, collaboration, tooling, oncall, design, documentation.",
+    ].join(" "),
+    inputSchema: {
+      type: "object",
+      properties: {
+        summary: { type: "string", description: "Impact-first summary of what was accomplished" },
+        category: { type: "string", description: "Category of work" },
+        impact: { type: "string", description: "Who/what benefited and how (metrics if possible)" },
+        tags: { type: "array", items: { type: "string" }, description: "Tags for filtering" },
+        repo: { type: "string", description: "Repository name (auto-detected if omitted)" },
+        branch: { type: "string", description: "Branch name (auto-detected if omitted)" },
+      },
+      required: ["summary"],
+    },
+  },
+  {
+    name: "review_brag_sheet",
+    description:
+      "Read recent entries from the user's brag sheet / work impact log. "
+      + "Also known as: review work log, show recent work, summarize accomplishments. "
+      + "Use to review, refine, or summarize work for performance reviews or manager discussions.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        weeks: { type: "number", description: "Number of recent weeks to show (default: 4)" },
+      },
+    },
+  },
+  {
+    name: "generate_work_log",
+    description: "Generate a complete work log markdown file from all records. Writes to disk.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        outputPath: {
+          type: "string",
+          description: "Output file path (defaults to work-log.md in data directory)",
+        },
+      },
+    },
+  },
+];
+
+// ── Tool handlers ───────────────────────────────────────────────────────────
+// Each handler returns an MCP tool result: { content: [{type:"text",text}], isError? }
+
+async function handleSaveToBragSheet(args) {
+  ensureInitialized();
+
+  if (!args?.summary || !String(args.summary).trim()) {
+    return toolError("summary is required and cannot be empty");
+  }
+
+  if (args.category && !isValidCategory(config, args.category)) {
+    const valid = getAllCategoryIds(config).join(", ");
+    return toolError(`invalid category "${args.category}". Valid: ${valid}`);
+  }
+
+  const entry = createEntryRecord({
+    summary: args.summary,
+    category: args.category || null,
+    impact: args.impact || null,
+    tags: Array.isArray(args.tags) ? args.tags : [],
+    repo: args.repo || null,
+    branch: args.branch || null,
+    sessionId: null, // MCP servers have no Copilot session context
+  });
+
+  writeRecord(dataDir, entry);
+
+  // Fire-and-forget git backup — never block tool response on network I/O.
+  backupToGit({ dataDir, gitConfig }).catch(() => {});
+
+  const label = args.category ? ` [${args.category}]` : "";
+  return toolText(`✅ Entry saved to brag sheet${label}: "${entry.summary}"`);
+}
+
+async function handleReviewBragSheet(args) {
+  ensureInitialized();
+
+  const weeks = args?.weeks ?? 4;
+  const records = readRecords(dataDir, {
+    since: new Date(Date.now() - weeks * 7 * 86400000).toISOString(),
+  });
+  const markdown = renderReviewSummary(records, { weeks, config });
+  const result = markdown || "No entries found for the requested period.";
+  const prefix = config?.preset === "microsoft"
+    ? "_Formatted for Connect review. Use impact framing: Did X → Result Y → Evidence Z._\n\n"
+    : "";
+  return toolText(`${prefix}${result}`);
+}
+
+async function handleGenerateWorkLog(args) {
+  ensureInitialized();
+
+  const records = readRecords(dataDir);
+  const markdown = renderMarkdown(records, { config });
+
+  const outputPath = args?.outputPath || detectBragSheetPath(dataDir);
+  ensureDir(path.dirname(outputPath));
+  atomicWriteText(outputPath, markdown);
+
+  // Fire-and-forget git backup.
+  backupToGit({ dataDir, gitConfig }).catch(() => {});
+
+  return toolText(`✅ Work log generated: ${outputPath} (${records.length} records)`);
+}
+
+const HANDLERS = {
+  save_to_brag_sheet: handleSaveToBragSheet,
+  review_brag_sheet: handleReviewBragSheet,
+  generate_work_log: handleGenerateWorkLog,
+};
+
+function toolText(text) {
+  return { content: [{ type: "text", text }] };
+}
+
+function toolError(message) {
+  return { content: [{ type: "text", text: `Error: ${message}` }], isError: true };
+}
+
+// ── JSON-RPC dispatcher ─────────────────────────────────────────────────────
+
+async function dispatch(message) {
+  const { id, method, params } = message;
+
+  // Notifications (no `id`) — process side effects, return nothing.
+  if (id === undefined || id === null) {
+    // We don't act on any notification today; "notifications/initialized" is
+    // accepted silently so hosts that send it don't see errors.
+    return null;
+  }
+
+  switch (method) {
+    case "initialize": {
+      return rpcResult(id, {
+        protocolVersion: PROTOCOL_VERSION,
+        capabilities: { tools: {} },
+        serverInfo: { name: SERVER_NAME, version: SERVER_VERSION },
+      });
+    }
+    case "tools/list": {
+      return rpcResult(id, { tools: TOOLS });
+    }
+    case "tools/call": {
+      const name = params?.name;
+      const args = params?.arguments || {};
+      const handler = HANDLERS[name];
+      if (!handler) {
+        return rpcError(id, -32602, `Unknown tool: ${name}`);
+      }
+      try {
+        const result = await handler(args);
+        return rpcResult(id, result);
+      } catch (err) {
+        try { logError(dataDir || ".", `tools/call:${name}`, err); } catch { /* noop */ }
+        // MCP convention: report tool execution failures as a normal result
+        // with isError=true rather than a JSON-RPC error, so the model can
+        // see and reason about the failure.
+        return rpcResult(id, toolError(err?.message || String(err)));
+      }
+    }
+    case "ping": {
+      return rpcResult(id, {});
+    }
+    default:
+      return rpcError(id, -32601, `Method not found: ${method}`);
+  }
+}
+
+function rpcResult(id, result) {
+  return { jsonrpc: "2.0", id, result };
+}
+
+function rpcError(id, code, message, data) {
+  const error = { code, message };
+  if (data !== undefined) error.data = data;
+  return { jsonrpc: "2.0", id, error };
+}
+
+// ── Stdio framing ───────────────────────────────────────────────────────────
+// MCP stdio transport uses newline-delimited JSON (one JSON-RPC message per
+// line). We buffer partial lines because Node may deliver chunked stdin.
+
+export async function runServer({ stdin = process.stdin, stdout = process.stdout } = {}) {
+  stdin.setEncoding("utf8");
+
+  let buffer = "";
+
+  const writeFrame = (msg) => {
+    if (!msg) return;
+    stdout.write(`${JSON.stringify(msg)}\n`);
+  };
+
+  const handleLine = async (line) => {
+    const trimmed = line.trim();
+    if (!trimmed) return;
+
+    let message;
+    try {
+      message = JSON.parse(trimmed);
+    } catch {
+      writeFrame(rpcError(null, -32700, "Parse error"));
+      return;
+    }
+
+    if (!message || message.jsonrpc !== "2.0") {
+      writeFrame(rpcError(message?.id ?? null, -32600, "Invalid Request"));
+      return;
+    }
+
+    try {
+      const response = await dispatch(message);
+      writeFrame(response);
+    } catch (err) {
+      writeFrame(rpcError(message.id ?? null, -32603, err?.message || "Internal error"));
+    }
+  };
+
+  return new Promise((resolve) => {
+    stdin.on("data", (chunk) => {
+      buffer += chunk;
+      let nl;
+      // Process every complete line currently in the buffer.
+      while ((nl = buffer.indexOf("\n")) !== -1) {
+        const line = buffer.slice(0, nl);
+        buffer = buffer.slice(nl + 1);
+        handleLine(line);
+      }
+    });
+    stdin.on("end", () => {
+      // Flush any trailing line without a newline.
+      if (buffer.trim()) {
+        handleLine(buffer);
+        buffer = "";
+      }
+      resolve();
+    });
+    stdin.on("error", (err) => {
+      try { logError(dataDir || ".", "stdin", err); } catch { /* noop */ }
+      resolve();
+    });
+  });
+}
+
+// Auto-start when invoked as the main module (so `node mcp-server.mjs` and
+// `bin/mcp-server.mjs` both Just Work). Tests can import { runServer } and
+// drive it with their own streams.
+const isMainModule =
+  process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+
+if (isMainModule) {
+  runServer().catch((err) => {
+    process.stderr.write(`[brag-sheet mcp] fatal: ${err?.stack || err}\n`);
+    process.exit(1);
+  });
+}

--- a/package.json
+++ b/package.json
@@ -1,7 +1,8 @@
 {
   "name": "copilot-brag-sheet",
   "version": "1.0.3",
-  "description": "Auto-track AI coding sessions into a structured work log. Zero dependencies, local-first.",
+  "description": "Auto-track AI coding sessions into a structured work log. Local-first, MCP-conformant.",
+  "mcpName": "io.github.microsoft/copilot-brag-sheet",
   "type": "module",
   "main": "extension.mjs",
   "bin": {
@@ -11,7 +12,12 @@
   },
   "scripts": {
     "test": "node --test",
+    "eval:seed": "node evals/seed.mjs",
     "prepublishOnly": "node --test"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.29.0",
+    "zod": "^3.25.0"
   },
   "keywords": [
     "copilot",
@@ -48,6 +54,7 @@
     "lib/",
     "bin/",
     "skills/",
+    "evals/",
     ".claude-plugin/",
     "plugin.json",
     "package.json",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "main": "extension.mjs",
   "bin": {
     "copilot-brag-sheet": "./bin/install.mjs",
-    "copilot-brag-sheet-setup": "./bin/setup.mjs"
+    "copilot-brag-sheet-setup": "./bin/setup.mjs",
+    "copilot-brag-sheet-mcp": "./bin/mcp-server.mjs"
   },
   "scripts": {
     "test": "node --test",
@@ -43,8 +44,11 @@
   },
   "files": [
     "extension.mjs",
+    "mcp-server.mjs",
     "lib/",
     "bin/",
+    "skills/",
+    ".claude-plugin/",
     "plugin.json",
     "package.json",
     "README.md",

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "copilot-brag-sheet",
-  "description": "Auto-track AI coding sessions into a structured work impact log. Zero dependencies, local-first.",
+  "description": "Auto-track AI coding sessions into a structured work impact log. Local-first, MCP-conformant.",
   "author": {
     "name": "Microsoft",
     "url": "https://www.microsoft.com"

--- a/skills/brag-sheet/SKILL.md
+++ b/skills/brag-sheet/SKILL.md
@@ -5,14 +5,14 @@ description: >
   reviews, self-reviews, promotion packets, and weekly updates. Uniquely mines Copilot
   CLI session logs to reconstruct forgotten work, plus git commits and GitHub PRs.
   Enforces a 3-part impact contract (action → result → evidence). Works standalone
-  with zero dependencies. Use this skill whenever the user asks to document,
-  summarize, reconstruct, or organize their engineering work — even if they don't
-  literally say "brag sheet". Trigger phrases include: "brag", "log work", "what
-  did I do", "backfill my work history", "performance review", "self-review",
-  "self assessment", "write impact statement", "review prep", "promo packet",
-  "promotion case", "weekly update", "status report", "accomplishments", "what
-  did I ship", "I forgot to log my work", "summarize my work", "track my wins",
-  "end of half", "career growth", "work journal".
+  with one runtime dependency: the official MCP SDK (when running the MCP server).
+  Use this skill whenever the user asks to document, summarize, reconstruct, or
+  organize their engineering work — even if they don't literally say "brag sheet".
+  Trigger phrases include: "brag", "log work", "what did I do", "backfill my work
+  history", "performance review", "self-review", "self assessment", "write impact
+  statement", "review prep", "promo packet", "promotion case", "weekly update",
+  "status report", "accomplishments", "what did I ship", "I forgot to log my work",
+  "summarize my work", "track my wins", "end of half", "career growth", "work journal".
 license: MIT
 compatibility: 'Cross-platform (Windows, macOS, Linux). Works with any GitHub Copilot CLI session. Optional: git, gh CLI.'
 metadata:

--- a/test/config.test.mjs
+++ b/test/config.test.mjs
@@ -2,6 +2,7 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
+import { tmpdir } from "node:os";
 
 import {
   DEFAULT_CONFIG,
@@ -14,7 +15,7 @@ import {
 } from "../lib/config.mjs";
 
 function createTempDir() {
-  return mkdtempSync(join(process.cwd(), "test-temp-config-"));
+  return mkdtempSync(join(tmpdir(), "test-temp-config-"));
 }
 
 test("loadConfig returns defaults when config.json is missing", () => {

--- a/test/mcp-server.test.mjs
+++ b/test/mcp-server.test.mjs
@@ -19,6 +19,7 @@ import { readRecords } from "../lib/storage.mjs";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const SERVER_PATH = join(__dirname, "..", "mcp-server.mjs");
+const BIN_PATH = join(__dirname, "..", "bin", "mcp-server.mjs");
 const SERVER_NAME = "brag-sheet-mcp-server";
 
 let dataDir;
@@ -102,6 +103,39 @@ function runRpc(requests, env = {}) {
 }
 
 describe("mcp-server: protocol handshake", () => {
+  it("bin entry point boots the server (regression: bin shim must call runServer)", async () => {
+    // The bin/mcp-server.mjs shim is what end users invoke via
+    // `npx copilot-brag-sheet-mcp` and `claude mcp add ... -- npx ...`.
+    // It must actually start the transport — driving SERVER_PATH directly is
+    // not enough to catch a broken shim.
+    const child = spawn(process.execPath, [BIN_PATH], {
+      env: { ...process.env, WORK_TRACKER_DIR: dataDir },
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    let stdout = "";
+    child.stdout.on("data", (b) => { stdout += b.toString("utf8"); });
+    child.stdin.write(`${JSON.stringify({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "initialize",
+      params: {
+        protocolVersion: "2024-11-05",
+        capabilities: {},
+        clientInfo: { name: "test-client", version: "1.0.0" },
+      },
+    })}\n`);
+    // Give the server a moment to respond before closing stdin.
+    await new Promise((r) => setTimeout(r, 500));
+    child.stdin.end();
+    const code = await new Promise((r) => child.on("close", r));
+
+    assert.equal(code, 0, "bin shim exited non-zero");
+    const lines = stdout.split("\n").filter((l) => l.trim());
+    const init = lines.map((l) => JSON.parse(l)).find((m) => m.id === 1);
+    assert.ok(init?.result?.serverInfo?.name, `bin shim never replied to initialize; stdout was: ${stdout}`);
+    assert.equal(init.result.serverInfo.name, SERVER_NAME);
+  });
+
   it("responds to initialize with protocol + capabilities + serverInfo", async () => {
     const { responses } = await runRpc([
       {

--- a/test/mcp-server.test.mjs
+++ b/test/mcp-server.test.mjs
@@ -19,6 +19,7 @@ import { readRecords } from "../lib/storage.mjs";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const SERVER_PATH = join(__dirname, "..", "mcp-server.mjs");
+const SERVER_NAME = "brag-sheet-mcp-server";
 
 let dataDir;
 
@@ -31,10 +32,14 @@ after(() => {
 });
 
 /**
- * Spawn the MCP server, send an array of requests as newline-delimited JSON
- * on stdin, close stdin, and collect newline-delimited JSON responses from
- * stdout. Notifications (no id) produce no response, so callers should only
- * count requests with ids.
+ * Spawn the MCP server, send each request as a newline-delimited JSON-RPC
+ * frame waiting for the matching response before sending the next, then
+ * close stdin and resolve with all collected responses. Notifications
+ * (no id) produce no response so they are dispatched without a wait.
+ *
+ * Sequential send mirrors how an MCP host actually drives the wire — one
+ * request, then await its matching response — and avoids races with the
+ * SDK's concurrent request-validation pipeline.
  */
 function runRpc(requests, env = {}) {
   return new Promise((resolve, reject) => {
@@ -43,31 +48,72 @@ function runRpc(requests, env = {}) {
       stdio: ["pipe", "pipe", "pipe"],
     });
 
-    let stdout = "";
+    let stdoutBuf = "";
     let stderr = "";
-    child.stdout.on("data", (b) => { stdout += b.toString("utf8"); });
+    const responses = [];
+    const waiters = new Map();
+
+    child.stdout.on("data", (b) => {
+      stdoutBuf += b.toString("utf8");
+      let nl;
+      while ((nl = stdoutBuf.indexOf("\n")) !== -1) {
+        const line = stdoutBuf.slice(0, nl).trim();
+        stdoutBuf = stdoutBuf.slice(nl + 1);
+        if (!line) continue;
+        let parsed;
+        try { parsed = JSON.parse(line); } catch { continue; }
+        responses.push(parsed);
+        const w = waiters.get(parsed.id);
+        if (w) {
+          waiters.delete(parsed.id);
+          w(parsed);
+        }
+      }
+    });
     child.stderr.on("data", (b) => { stderr += b.toString("utf8"); });
 
     child.on("error", reject);
     child.on("close", (code) => {
-      const responses = stdout
-        .split("\n")
-        .filter((line) => line.trim().length > 0)
-        .map((line) => JSON.parse(line));
+      if (stdoutBuf.trim()) {
+        try { responses.push(JSON.parse(stdoutBuf.trim())); } catch { /* noop */ }
+      }
       resolve({ responses, stderr, code });
     });
 
-    for (const req of requests) {
-      child.stdin.write(`${JSON.stringify(req)}\n`);
-    }
-    child.stdin.end();
+    (async () => {
+      for (const req of requests) {
+        if (req.id == null) {
+          // Notification — no response expected, write and move on.
+          child.stdin.write(`${JSON.stringify(req)}\n`);
+          continue;
+        }
+        const got = new Promise((r) => waiters.set(req.id, r));
+        child.stdin.write(`${JSON.stringify(req)}\n`);
+        // Wait at most 5 s per request so a hung server fails the test
+        // quickly rather than wedging the suite.
+        await Promise.race([
+          got,
+          new Promise((r) => setTimeout(r, 5000)),
+        ]);
+      }
+      child.stdin.end();
+    })().catch(reject);
   });
 }
 
 describe("mcp-server: protocol handshake", () => {
   it("responds to initialize with protocol + capabilities + serverInfo", async () => {
     const { responses } = await runRpc([
-      { jsonrpc: "2.0", id: 1, method: "initialize", params: {} },
+      {
+        jsonrpc: "2.0",
+        id: 1,
+        method: "initialize",
+        params: {
+          protocolVersion: "2024-11-05",
+          capabilities: {},
+          clientInfo: { name: "test-client", version: "1.0.0" },
+        },
+      },
     ]);
 
     assert.equal(responses.length, 1, "expected one response");
@@ -78,7 +124,7 @@ describe("mcp-server: protocol handshake", () => {
     assert.equal(typeof res.result.protocolVersion, "string");
     assert.ok(res.result.capabilities, "capabilities missing");
     assert.ok(res.result.capabilities.tools !== undefined, "tools capability missing");
-    assert.equal(res.result.serverInfo?.name, "copilot-brag-sheet");
+    assert.equal(res.result.serverInfo?.name, SERVER_NAME);
     assert.ok(res.result.serverInfo?.version, "serverInfo.version missing");
   });
 
@@ -99,8 +145,11 @@ describe("mcp-server: protocol handshake", () => {
     assert.equal(responses[0].error?.code, -32601);
   });
 
-  it("returns -32700 for malformed JSON", async () => {
-    // Bypass runRpc helper because we need to send raw garbage bytes.
+  it("does not crash on malformed JSON over stdio", async () => {
+    // The MCP SDK's StdioServerTransport routes parse failures to its
+    // `onerror` callback rather than emitting a JSON-RPC parse-error frame;
+    // the contract we care about is that the process stays healthy and the
+    // next valid frame still gets a response.
     const child = spawn(process.execPath, [SERVER_PATH], {
       env: { ...process.env, WORK_TRACKER_DIR: dataDir },
       stdio: ["pipe", "pipe", "pipe"],
@@ -109,13 +158,14 @@ describe("mcp-server: protocol handshake", () => {
     child.stdout.on("data", (b) => { stdout += b.toString("utf8"); });
 
     child.stdin.write("this is not json\n");
+    child.stdin.write(`${JSON.stringify({ jsonrpc: "2.0", id: 1, method: "ping" })}\n`);
     child.stdin.end();
-    await new Promise((r) => child.on("close", r));
+    const code = await new Promise((r) => child.on("close", r));
 
+    assert.equal(code, 0, "server crashed on malformed input");
     const lines = stdout.split("\n").filter((l) => l.trim());
-    assert.equal(lines.length, 1);
-    const res = JSON.parse(lines[0]);
-    assert.equal(res.error?.code, -32700);
+    const ping = lines.map((l) => JSON.parse(l)).find((m) => m.id === 1);
+    assert.ok(ping?.result, `expected ping response after garbage frame, got ${stdout}`);
   });
 });
 
@@ -133,6 +183,17 @@ describe("mcp-server: tools/list", () => {
       assert.equal(typeof tool.description, "string");
       assert.equal(tool.inputSchema.type, "object");
       assert.ok(tool.inputSchema.properties, `${tool.name} missing properties`);
+      // .strict() on every input schema → JSON Schema additionalProperties=false.
+      assert.equal(
+        tool.inputSchema.additionalProperties,
+        false,
+        `${tool.name} inputSchema should be strict (additionalProperties=false)`,
+      );
+      // Every tool exposes response_format.
+      assert.ok(
+        tool.inputSchema.properties.response_format,
+        `${tool.name} missing response_format`,
+      );
     }
 
     const save = tools.find((t) => t.name === "save_to_brag_sheet");
@@ -140,11 +201,54 @@ describe("mcp-server: tools/list", () => {
     assert.ok(save.inputSchema.properties.summary);
     assert.ok(save.inputSchema.properties.category);
     assert.ok(save.inputSchema.properties.tags);
+
+    const review = tools.find((t) => t.name === "review_brag_sheet");
+    assert.ok(review.inputSchema.properties.weeks, "review missing weeks");
+    assert.ok(review.inputSchema.properties.limit, "review missing limit");
+    assert.ok(review.inputSchema.properties.offset, "review missing offset");
+  });
+
+  it("advertises outputSchema and tool annotations for every tool", async () => {
+    const { responses } = await runRpc([
+      { jsonrpc: "2.0", id: 1, method: "tools/list" },
+    ]);
+    const tools = responses[0].result.tools;
+
+    for (const tool of tools) {
+      assert.ok(tool.outputSchema, `${tool.name} missing outputSchema`);
+      assert.equal(tool.outputSchema.type, "object", `${tool.name} outputSchema not an object`);
+      assert.ok(tool.outputSchema.properties, `${tool.name} outputSchema missing properties`);
+      assert.ok(tool.annotations, `${tool.name} missing annotations`);
+      for (const hint of ["readOnlyHint", "destructiveHint", "idempotentHint", "openWorldHint"]) {
+        assert.equal(typeof tool.annotations[hint], "boolean", `${tool.name}.${hint} should be boolean`);
+      }
+    }
+
+    const save = tools.find((t) => t.name === "save_to_brag_sheet");
+    assert.deepEqual(
+      Object.keys(save.outputSchema.properties).sort(),
+      ["category", "entryId", "success", "summary", "timestamp"],
+    );
+
+    const review = tools.find((t) => t.name === "review_brag_sheet");
+    assert.equal(review.annotations.readOnlyHint, true);
+    assert.equal(review.annotations.destructiveHint, false);
+    assert.deepEqual(
+      Object.keys(review.outputSchema.properties).sort(),
+      ["count", "hasMore", "items", "nextOffset", "offset", "total", "weeksCovered"],
+    );
+
+    const generate = tools.find((t) => t.name === "generate_work_log");
+    assert.equal(generate.annotations.destructiveHint, true);
+    assert.deepEqual(
+      Object.keys(generate.outputSchema.properties).sort(),
+      ["bytesWritten", "outputPath", "recordCount", "success"],
+    );
   });
 });
 
 describe("mcp-server: save_to_brag_sheet", () => {
-  it("persists an entry record and returns a confirmation", async () => {
+  it("persists an entry record and returns a confirmation with structured output", async () => {
     const { responses } = await runRpc([
       {
         jsonrpc: "2.0",
@@ -155,7 +259,7 @@ describe("mcp-server: save_to_brag_sheet", () => {
           arguments: {
             summary: "Built the MCP server scaffold for cross-engine support",
             category: "tooling",
-            impact: "Unblocks Claude Code / Codex / Cursor users",
+            impact: "Unblocks more MCP hosts",
             tags: ["mcp", "scaffold"],
             repo: "copilot-brag-sheet",
             branch: "mcp-server-scaffold",
@@ -168,6 +272,11 @@ describe("mcp-server: save_to_brag_sheet", () => {
     assert.ok(res.result, `expected result, got ${JSON.stringify(res)}`);
     assert.ok(!res.result.isError, "tool returned isError");
     assert.match(res.result.content[0].text, /saved to brag sheet/i);
+    assert.ok(res.result.structuredContent, "missing structuredContent");
+    assert.equal(res.result.structuredContent.success, true);
+    assert.equal(res.result.structuredContent.category, "tooling");
+    assert.equal(typeof res.result.structuredContent.entryId, "string");
+    assert.equal(typeof res.result.structuredContent.timestamp, "string");
 
     const records = readRecords(dataDir, { type: "entry" });
     const matches = records.filter(
@@ -179,7 +288,10 @@ describe("mcp-server: save_to_brag_sheet", () => {
     assert.equal(matches[0].repo, "copilot-brag-sheet");
   });
 
-  it("returns isError=true when summary is missing", async () => {
+  it("rejects missing summary at the validation layer (Zod-driven)", async () => {
+    // The SDK validates the inputSchema before invoking the handler and
+    // surfaces validation failures as a tool result with isError=true and
+    // the JSON-RPC InvalidParams code (-32602) embedded in the text.
     const { responses } = await runRpc([
       {
         jsonrpc: "2.0",
@@ -188,8 +300,27 @@ describe("mcp-server: save_to_brag_sheet", () => {
         params: { name: "save_to_brag_sheet", arguments: {} },
       },
     ]);
-    assert.equal(responses[0].result.isError, true);
-    assert.match(responses[0].result.content[0].text, /summary is required/i);
+    assert.equal(responses[0].result?.isError, true, JSON.stringify(responses[0]));
+    assert.match(responses[0].result.content[0].text, /-32602|summary|required|invalid/i);
+  });
+
+  it("rejects unknown fields because every input schema is strict()", async () => {
+    const { responses } = await runRpc([
+      {
+        jsonrpc: "2.0",
+        id: 1,
+        method: "tools/call",
+        params: {
+          name: "save_to_brag_sheet",
+          arguments: { summary: "ok", not_a_real_field: "boom" },
+        },
+      },
+    ]);
+    assert.equal(responses[0].result?.isError, true, JSON.stringify(responses[0]));
+    assert.match(
+      responses[0].result.content[0].text,
+      /unrecognized|not_a_real_field|-32602/i,
+    );
   });
 
   it("returns isError=true for an invalid category", async () => {
@@ -207,10 +338,36 @@ describe("mcp-server: save_to_brag_sheet", () => {
     assert.equal(responses[0].result.isError, true);
     assert.match(responses[0].result.content[0].text, /invalid category/i);
   });
+
+  it("emits JSON when response_format='json'", async () => {
+    const { responses } = await runRpc([
+      {
+        jsonrpc: "2.0",
+        id: 1,
+        method: "tools/call",
+        params: {
+          name: "save_to_brag_sheet",
+          arguments: {
+            summary: "Round-trip JSON output check",
+            category: "documentation",
+            response_format: "json",
+          },
+        },
+      },
+    ]);
+    const res = responses[0].result;
+    assert.ok(!res.isError, JSON.stringify(res));
+    const parsed = JSON.parse(res.content[0].text);
+    assert.equal(parsed.success, true);
+    assert.equal(parsed.category, "documentation");
+    assert.equal(parsed.summary, "Round-trip JSON output check");
+    assert.equal(typeof parsed.entryId, "string");
+    assert.deepEqual(parsed, res.structuredContent);
+  });
 });
 
 describe("mcp-server: review_brag_sheet", () => {
-  it("returns markdown for entries within the requested window", async () => {
+  it("returns a paginated envelope with markdown and structured items", async () => {
     // Seed via save_to_brag_sheet, then review.
     const { responses } = await runRpc([
       {
@@ -226,14 +383,84 @@ describe("mcp-server: review_brag_sheet", () => {
         jsonrpc: "2.0",
         id: 2,
         method: "tools/call",
-        params: { name: "review_brag_sheet", arguments: { weeks: 4 } },
+        params: { name: "review_brag_sheet", arguments: { weeks: 4, limit: 50 } },
       },
     ]);
 
     assert.equal(responses.length, 2);
-    const review = responses[1].result;
+    const review = responses.find((r) => r.id === 2).result;
     assert.ok(!review.isError);
     assert.match(review.content[0].text, /Review-test entry alpha/);
+    assert.ok(review.structuredContent, "missing structuredContent");
+    const sc = review.structuredContent;
+    assert.equal(typeof sc.total, "number");
+    assert.equal(typeof sc.count, "number");
+    assert.equal(sc.offset, 0);
+    assert.equal(sc.weeksCovered, 4);
+    assert.equal(typeof sc.hasMore, "boolean");
+    assert.ok(Array.isArray(sc.items));
+    assert.ok(sc.items.length >= 1, "expected at least the alpha entry");
+    assert.ok(sc.items.every((it) => typeof it.id === "string"), "items missing id");
+  });
+
+  it("respects limit and offset, and reports hasMore + nextOffset", async () => {
+    // Seed a couple more entries so we have enough records to page through.
+    const seeds = ["pager-alpha", "pager-beta", "pager-gamma"];
+    const reqs = seeds.map((s, i) => ({
+      jsonrpc: "2.0",
+      id: 100 + i,
+      method: "tools/call",
+      params: {
+        name: "save_to_brag_sheet",
+        arguments: { summary: s, category: "documentation" },
+      },
+    }));
+    reqs.push({
+      jsonrpc: "2.0",
+      id: 200,
+      method: "tools/call",
+      params: { name: "review_brag_sheet", arguments: { weeks: 4, limit: 2, offset: 0 } },
+    });
+    reqs.push({
+      jsonrpc: "2.0",
+      id: 201,
+      method: "tools/call",
+      params: { name: "review_brag_sheet", arguments: { weeks: 4, limit: 2, offset: 2 } },
+    });
+
+    const { responses } = await runRpc(reqs);
+    const page1 = responses.find((r) => r.id === 200).result.structuredContent;
+    const page2 = responses.find((r) => r.id === 201).result.structuredContent;
+
+    assert.equal(page1.count, 2);
+    assert.equal(page1.offset, 0);
+    assert.equal(page1.hasMore, true);
+    assert.equal(page1.nextOffset, 2);
+    assert.ok(page1.total >= 4);
+
+    assert.equal(page2.offset, 2);
+    assert.ok(page2.count >= 1);
+    // hasMore depends on the seeded entries from prior tests; just check the type.
+    assert.equal(typeof page2.hasMore, "boolean");
+  });
+
+  it("emits raw JSON when response_format='json'", async () => {
+    const { responses } = await runRpc([
+      {
+        jsonrpc: "2.0",
+        id: 1,
+        method: "tools/call",
+        params: {
+          name: "review_brag_sheet",
+          arguments: { weeks: 4, limit: 5, response_format: "json" },
+        },
+      },
+    ]);
+    const res = responses[0].result;
+    assert.ok(!res.isError, JSON.stringify(res));
+    const parsed = JSON.parse(res.content[0].text);
+    assert.deepEqual(parsed, res.structuredContent);
+    assert.equal(parsed.weeksCovered, 4);
   });
 });
 
@@ -258,17 +485,26 @@ describe("mcp-server: generate_work_log", () => {
       },
     ]);
 
-    const gen = responses[1].result;
+    const gen = responses.find((r) => r.id === 2).result;
     assert.ok(!gen.isError, gen.content?.[0]?.text);
     assert.match(gen.content[0].text, /Work log generated/);
     assert.ok(existsSync(outputPath), `expected file at ${outputPath}`);
     const md = readFileSync(outputPath, "utf8");
     assert.ok(md.length > 0, "work log file is empty");
+    const sc = gen.structuredContent;
+    assert.equal(sc.success, true);
+    assert.equal(sc.outputPath, outputPath);
+    assert.equal(typeof sc.recordCount, "number");
+    assert.equal(typeof sc.bytesWritten, "number");
+    assert.ok(sc.bytesWritten > 0);
   });
 });
 
 describe("mcp-server: unknown tool", () => {
-  it("returns a JSON-RPC error for an unknown tool name", async () => {
+  it("returns a tool-error for an unknown tool name", async () => {
+    // McpServer surfaces unknown-tool as a tool-result with isError=true and
+    // the InvalidParams code (-32602) embedded in the text — the protocol
+    // frame still has `result`, not `error`.
     const { responses } = await runRpc([
       {
         jsonrpc: "2.0",
@@ -277,7 +513,7 @@ describe("mcp-server: unknown tool", () => {
         params: { name: "does_not_exist", arguments: {} },
       },
     ]);
-    assert.equal(responses[0].error?.code, -32602);
-    assert.match(responses[0].error.message, /Unknown tool/);
+    assert.equal(responses[0].result?.isError, true, JSON.stringify(responses[0]));
+    assert.match(responses[0].result.content[0].text, /not found|unknown|-32602/i);
   });
 });

--- a/test/mcp-server.test.mjs
+++ b/test/mcp-server.test.mjs
@@ -532,6 +532,30 @@ describe("mcp-server: generate_work_log", () => {
     assert.equal(typeof sc.bytesWritten, "number");
     assert.ok(sc.bytesWritten > 0);
   });
+
+  it("rejects a relative outputPath rather than writing to the host's cwd", async () => {
+    // Without this guard a model could pass `outputPath: "README.md"` and
+    // clobber a file in whatever directory the MCP host launched the server
+    // from. The schema must require absolute paths.
+    const { responses } = await runRpc([
+      {
+        jsonrpc: "2.0",
+        id: 1,
+        method: "tools/call",
+        params: {
+          name: "generate_work_log",
+          arguments: { outputPath: "relative/path.md" },
+        },
+      },
+    ]);
+    const res = responses[0];
+    assert.equal(res.result?.isError, true, JSON.stringify(res));
+    assert.match(
+      res.result.content[0].text,
+      /absolute/i,
+      `expected an 'absolute path' error, got: ${res.result.content[0].text}`,
+    );
+  });
 });
 
 describe("mcp-server: unknown tool", () => {

--- a/test/mcp-server.test.mjs
+++ b/test/mcp-server.test.mjs
@@ -1,0 +1,283 @@
+/**
+ * Integration tests for mcp-server.mjs
+ *
+ * Spawns the server as a subprocess and drives it over stdio with real
+ * JSON-RPC frames. Each test asserts both the wire-protocol shape and that
+ * the underlying lib/ side-effects happened (records on disk, work-log file
+ * written, etc.) using an isolated WORK_TRACKER_DIR per test run.
+ */
+
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { mkdtempSync, existsSync, readFileSync, rmSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { tmpdir } from "node:os";
+import { fileURLToPath } from "node:url";
+
+import { readRecords } from "../lib/storage.mjs";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const SERVER_PATH = join(__dirname, "..", "mcp-server.mjs");
+
+let dataDir;
+
+before(() => {
+  dataDir = mkdtempSync(join(tmpdir(), "mcp-test-"));
+});
+
+after(() => {
+  try { rmSync(dataDir, { recursive: true, force: true }); } catch { /* noop */ }
+});
+
+/**
+ * Spawn the MCP server, send an array of requests as newline-delimited JSON
+ * on stdin, close stdin, and collect newline-delimited JSON responses from
+ * stdout. Notifications (no id) produce no response, so callers should only
+ * count requests with ids.
+ */
+function runRpc(requests, env = {}) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, [SERVER_PATH], {
+      env: { ...process.env, WORK_TRACKER_DIR: dataDir, ...env },
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (b) => { stdout += b.toString("utf8"); });
+    child.stderr.on("data", (b) => { stderr += b.toString("utf8"); });
+
+    child.on("error", reject);
+    child.on("close", (code) => {
+      const responses = stdout
+        .split("\n")
+        .filter((line) => line.trim().length > 0)
+        .map((line) => JSON.parse(line));
+      resolve({ responses, stderr, code });
+    });
+
+    for (const req of requests) {
+      child.stdin.write(`${JSON.stringify(req)}\n`);
+    }
+    child.stdin.end();
+  });
+}
+
+describe("mcp-server: protocol handshake", () => {
+  it("responds to initialize with protocol + capabilities + serverInfo", async () => {
+    const { responses } = await runRpc([
+      { jsonrpc: "2.0", id: 1, method: "initialize", params: {} },
+    ]);
+
+    assert.equal(responses.length, 1, "expected one response");
+    const [res] = responses;
+    assert.equal(res.jsonrpc, "2.0");
+    assert.equal(res.id, 1);
+    assert.ok(res.result, "result missing");
+    assert.equal(typeof res.result.protocolVersion, "string");
+    assert.ok(res.result.capabilities, "capabilities missing");
+    assert.ok(res.result.capabilities.tools !== undefined, "tools capability missing");
+    assert.equal(res.result.serverInfo?.name, "copilot-brag-sheet");
+    assert.ok(res.result.serverInfo?.version, "serverInfo.version missing");
+  });
+
+  it("ignores notifications (no id) without responding or erroring", async () => {
+    const { responses } = await runRpc([
+      { jsonrpc: "2.0", method: "notifications/initialized" },
+      { jsonrpc: "2.0", id: 1, method: "ping" },
+    ]);
+    assert.equal(responses.length, 1, "only the ping should produce a response");
+    assert.equal(responses[0].id, 1);
+    assert.deepEqual(responses[0].result, {});
+  });
+
+  it("returns -32601 for unknown methods", async () => {
+    const { responses } = await runRpc([
+      { jsonrpc: "2.0", id: 1, method: "does/not/exist" },
+    ]);
+    assert.equal(responses[0].error?.code, -32601);
+  });
+
+  it("returns -32700 for malformed JSON", async () => {
+    // Bypass runRpc helper because we need to send raw garbage bytes.
+    const child = spawn(process.execPath, [SERVER_PATH], {
+      env: { ...process.env, WORK_TRACKER_DIR: dataDir },
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    let stdout = "";
+    child.stdout.on("data", (b) => { stdout += b.toString("utf8"); });
+
+    child.stdin.write("this is not json\n");
+    child.stdin.end();
+    await new Promise((r) => child.on("close", r));
+
+    const lines = stdout.split("\n").filter((l) => l.trim());
+    assert.equal(lines.length, 1);
+    const res = JSON.parse(lines[0]);
+    assert.equal(res.error?.code, -32700);
+  });
+});
+
+describe("mcp-server: tools/list", () => {
+  it("lists exactly the three brag-sheet tools with input schemas", async () => {
+    const { responses } = await runRpc([
+      { jsonrpc: "2.0", id: 1, method: "tools/list" },
+    ]);
+    const tools = responses[0].result.tools;
+    assert.equal(tools.length, 3);
+    const names = tools.map((t) => t.name).sort();
+    assert.deepEqual(names, ["generate_work_log", "review_brag_sheet", "save_to_brag_sheet"]);
+
+    for (const tool of tools) {
+      assert.equal(typeof tool.description, "string");
+      assert.equal(tool.inputSchema.type, "object");
+      assert.ok(tool.inputSchema.properties, `${tool.name} missing properties`);
+    }
+
+    const save = tools.find((t) => t.name === "save_to_brag_sheet");
+    assert.deepEqual(save.inputSchema.required, ["summary"]);
+    assert.ok(save.inputSchema.properties.summary);
+    assert.ok(save.inputSchema.properties.category);
+    assert.ok(save.inputSchema.properties.tags);
+  });
+});
+
+describe("mcp-server: save_to_brag_sheet", () => {
+  it("persists an entry record and returns a confirmation", async () => {
+    const { responses } = await runRpc([
+      {
+        jsonrpc: "2.0",
+        id: 1,
+        method: "tools/call",
+        params: {
+          name: "save_to_brag_sheet",
+          arguments: {
+            summary: "Built the MCP server scaffold for cross-engine support",
+            category: "tooling",
+            impact: "Unblocks Claude Code / Codex / Cursor users",
+            tags: ["mcp", "scaffold"],
+            repo: "copilot-brag-sheet",
+            branch: "mcp-server-scaffold",
+          },
+        },
+      },
+    ]);
+
+    const res = responses[0];
+    assert.ok(res.result, `expected result, got ${JSON.stringify(res)}`);
+    assert.ok(!res.result.isError, "tool returned isError");
+    assert.match(res.result.content[0].text, /saved to brag sheet/i);
+
+    const records = readRecords(dataDir, { type: "entry" });
+    const matches = records.filter(
+      (r) => r.summary === "Built the MCP server scaffold for cross-engine support",
+    );
+    assert.equal(matches.length, 1);
+    assert.equal(matches[0].category, "tooling");
+    assert.deepEqual(matches[0].tags, ["mcp", "scaffold"]);
+    assert.equal(matches[0].repo, "copilot-brag-sheet");
+  });
+
+  it("returns isError=true when summary is missing", async () => {
+    const { responses } = await runRpc([
+      {
+        jsonrpc: "2.0",
+        id: 1,
+        method: "tools/call",
+        params: { name: "save_to_brag_sheet", arguments: {} },
+      },
+    ]);
+    assert.equal(responses[0].result.isError, true);
+    assert.match(responses[0].result.content[0].text, /summary is required/i);
+  });
+
+  it("returns isError=true for an invalid category", async () => {
+    const { responses } = await runRpc([
+      {
+        jsonrpc: "2.0",
+        id: 1,
+        method: "tools/call",
+        params: {
+          name: "save_to_brag_sheet",
+          arguments: { summary: "x", category: "not-a-real-category" },
+        },
+      },
+    ]);
+    assert.equal(responses[0].result.isError, true);
+    assert.match(responses[0].result.content[0].text, /invalid category/i);
+  });
+});
+
+describe("mcp-server: review_brag_sheet", () => {
+  it("returns markdown for entries within the requested window", async () => {
+    // Seed via save_to_brag_sheet, then review.
+    const { responses } = await runRpc([
+      {
+        jsonrpc: "2.0",
+        id: 1,
+        method: "tools/call",
+        params: {
+          name: "save_to_brag_sheet",
+          arguments: { summary: "Review-test entry alpha", category: "documentation" },
+        },
+      },
+      {
+        jsonrpc: "2.0",
+        id: 2,
+        method: "tools/call",
+        params: { name: "review_brag_sheet", arguments: { weeks: 4 } },
+      },
+    ]);
+
+    assert.equal(responses.length, 2);
+    const review = responses[1].result;
+    assert.ok(!review.isError);
+    assert.match(review.content[0].text, /Review-test entry alpha/);
+  });
+});
+
+describe("mcp-server: generate_work_log", () => {
+  it("writes a markdown file at the requested outputPath", async () => {
+    const outputPath = join(dataDir, "out", "work-log.md");
+    const { responses } = await runRpc([
+      {
+        jsonrpc: "2.0",
+        id: 1,
+        method: "tools/call",
+        params: {
+          name: "save_to_brag_sheet",
+          arguments: { summary: "Work-log fixture entry", category: "tooling" },
+        },
+      },
+      {
+        jsonrpc: "2.0",
+        id: 2,
+        method: "tools/call",
+        params: { name: "generate_work_log", arguments: { outputPath } },
+      },
+    ]);
+
+    const gen = responses[1].result;
+    assert.ok(!gen.isError, gen.content?.[0]?.text);
+    assert.match(gen.content[0].text, /Work log generated/);
+    assert.ok(existsSync(outputPath), `expected file at ${outputPath}`);
+    const md = readFileSync(outputPath, "utf8");
+    assert.ok(md.length > 0, "work log file is empty");
+  });
+});
+
+describe("mcp-server: unknown tool", () => {
+  it("returns a JSON-RPC error for an unknown tool name", async () => {
+    const { responses } = await runRpc([
+      {
+        jsonrpc: "2.0",
+        id: 1,
+        method: "tools/call",
+        params: { name: "does_not_exist", arguments: {} },
+      },
+    ]);
+    assert.equal(responses[0].error?.code, -32602);
+    assert.match(responses[0].error.message, /Unknown tool/);
+  });
+});

--- a/test/pack-smoke.test.mjs
+++ b/test/pack-smoke.test.mjs
@@ -1,0 +1,171 @@
+/**
+ * Packed-tarball smoke test.
+ *
+ * Builds the package the way `npm publish` would, installs the resulting
+ * tarball into a scratch directory, then drives the installed MCP bin
+ * over JSON-RPC. Catches the class of bug where source-tree tests pass
+ * but the published package is broken — missing files in the tarball,
+ * wrong bin paths, broken `import` traversals across the install layout,
+ * or a release workflow that forgot to install dependencies.
+ *
+ * This is the gate that would have caught the v1.0.4 bin-shim bug before
+ * the regression test we added at the source-tree level.
+ *
+ * Skipped when `BRAG_SHEET_SKIP_PACK_TEST=1` (offline laptops, locked-down
+ * sandboxes). Always runs in CI.
+ */
+
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert/strict";
+import { spawn, spawnSync } from "node:child_process";
+import { mkdtempSync, readdirSync, rmSync } from "node:fs";
+import { join, dirname, resolve } from "node:path";
+import { tmpdir, platform } from "node:os";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const PKG_ROOT = resolve(__dirname, "..");
+const IS_WINDOWS = platform() === "win32";
+const SKIP = process.env.BRAG_SHEET_SKIP_PACK_TEST === "1";
+
+let workDir;
+let installDir;
+let binPath;
+
+function runSync(cmd, args, opts = {}) {
+  const r = spawnSync(cmd, args, {
+    encoding: "utf8",
+    shell: IS_WINDOWS,
+    ...opts,
+  });
+  if (r.status !== 0) {
+    throw new Error(
+      `${cmd} ${args.join(" ")} failed (exit ${r.status})\nstdout: ${r.stdout}\nstderr: ${r.stderr}`,
+    );
+  }
+  return r;
+}
+
+before(() => {
+  if (SKIP) return;
+  workDir = mkdtempSync(join(tmpdir(), "bs-pack-"));
+  // 1. Build the tarball from the source tree.
+  runSync("npm", ["pack", "--pack-destination", workDir], { cwd: PKG_ROOT });
+  const tgz = readdirSync(workDir).find((f) => f.endsWith(".tgz"));
+  if (!tgz) throw new Error(`npm pack produced no tarball in ${workDir}`);
+  // 2. Install it into a scratch prefix. --no-audit --no-fund keeps logs
+  //    quiet; --omit=dev avoids pulling devDeps we do not have.
+  installDir = join(workDir, "install");
+  runSync("npm", [
+    "install",
+    "--no-audit",
+    "--no-fund",
+    "--omit=dev",
+    "--prefix",
+    installDir,
+    join(workDir, tgz),
+  ]);
+  // 3. Resolve the bin the way an MCP host would after `npx -y --package
+  //    copilot-brag-sheet copilot-brag-sheet-mcp`. We intentionally walk to
+  //    the file (not the .bin shim) because the JSON-RPC channel needs a
+  //    plain `node <file>` invocation we can spawn portably across OSes.
+  binPath = join(
+    installDir,
+    "node_modules",
+    "copilot-brag-sheet",
+    "bin",
+    "mcp-server.mjs",
+  );
+});
+
+after(() => {
+  if (SKIP || !workDir) return;
+  try { rmSync(workDir, { recursive: true, force: true }); } catch { /* noop */ }
+});
+
+describe("packed tarball: MCP bin smoke", { skip: SKIP }, () => {
+  it("the published bin completes initialize + tools/list", async () => {
+    const dataDir = mkdtempSync(join(tmpdir(), "bs-pack-data-"));
+    try {
+      const { responses, code, stderr } = await runRpc(binPath, dataDir, [
+        {
+          jsonrpc: "2.0",
+          id: 1,
+          method: "initialize",
+          params: {
+            protocolVersion: "2024-11-05",
+            capabilities: {},
+            clientInfo: { name: "pack-smoke", version: "1.0.0" },
+          },
+        },
+        { jsonrpc: "2.0", id: 2, method: "tools/list" },
+      ]);
+      assert.equal(code, 0, `bin exited non-zero. stderr: ${stderr}`);
+      const init = responses.find((r) => r.id === 1);
+      assert.equal(
+        init?.result?.serverInfo?.name,
+        "brag-sheet-mcp-server",
+        `initialize did not return serverInfo. responses: ${JSON.stringify(responses)}\nstderr: ${stderr}`,
+      );
+      const list = responses.find((r) => r.id === 2);
+      const names = (list?.result?.tools ?? []).map((t) => t.name).sort();
+      assert.deepEqual(names, [
+        "generate_work_log",
+        "review_brag_sheet",
+        "save_to_brag_sheet",
+      ]);
+    } finally {
+      try { rmSync(dataDir, { recursive: true, force: true }); } catch { /* noop */ }
+    }
+  });
+});
+
+function runRpc(bin, dataDir, requests) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, [bin], {
+      env: { ...process.env, WORK_TRACKER_DIR: dataDir },
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    let stdoutBuf = "";
+    let stderr = "";
+    const responses = [];
+    const waiters = new Map();
+    const timeout = setTimeout(() => {
+      try { child.kill("SIGTERM"); } catch { /* noop */ }
+      reject(new Error(`pack-smoke RPC timed out after 30s. stderr: ${stderr}`));
+    }, 30_000);
+
+    child.stdout.on("data", (b) => {
+      stdoutBuf += b.toString("utf8");
+      let nl;
+      while ((nl = stdoutBuf.indexOf("\n")) !== -1) {
+        const line = stdoutBuf.slice(0, nl).trim();
+        stdoutBuf = stdoutBuf.slice(nl + 1);
+        if (!line) continue;
+        let parsed;
+        try { parsed = JSON.parse(line); } catch { continue; }
+        responses.push(parsed);
+        const w = waiters.get(parsed.id);
+        if (w) {
+          waiters.delete(parsed.id);
+          w(parsed);
+        }
+      }
+    });
+    child.stderr.on("data", (b) => { stderr += b.toString("utf8"); });
+    child.on("error", (err) => { clearTimeout(timeout); reject(err); });
+    child.on("close", (code) => {
+      clearTimeout(timeout);
+      resolve({ responses, code, stderr });
+    });
+
+    (async () => {
+      for (const req of requests) {
+        const got = new Promise((r) => waiters.set(req.id, r));
+        child.stdin.write(`${JSON.stringify(req)}\n`);
+        await Promise.race([got, new Promise((r) => setTimeout(r, 5000))]);
+      }
+      child.stdin.end();
+    })().catch((err) => { clearTimeout(timeout); reject(err); });
+  });
+}


### PR DESCRIPTION
## Summary

Rewrites `mcp-server.mjs` on the official `@modelcontextprotocol/sdk` and adds a 10-question evaluation suite. Aligns the server with the MCP protocol's reference implementation guidance: strict input schemas, structured outputs, tool annotations, and a uniform `response_format` switch on every tool. Flips the project's brand surface from "zero dependencies" to "MCP-conformant" — the `lib/` modules remain dependency-free; only `mcp-server.mjs` pulls in the SDK and Zod.

## What changes

### `mcp-server.mjs` (full rewrite, 318 → 460 LOC)

- Built on `@modelcontextprotocol/sdk`'s `McpServer` + `StdioServerTransport` (no hand-rolled JSON-RPC dispatcher).
- Server identity: `brag-sheet-mcp-server` (Node convention `{service}-mcp-server`).
- All input schemas declared with Zod and marked `.strict()` — surfaces as `additionalProperties: false` in the published JSON Schema. Unknown fields are rejected with `-32602`.
- All output schemas declared and registered. Field names are camelCase: `success`, `entryId`, `outputPath`, `recordCount`, `bytesWritten`, `total`, `count`, `offset`, `hasMore`, `nextOffset`, `weeksCovered`, `items`.
- All three tools accept `response_format: "markdown" | "json"` (default `"markdown"`). JSON mode round-trips the structured payload verbatim in `content[0].text`.
- Tool annotations populated: `title`, `readOnlyHint`, `destructiveHint`, `idempotentHint`, `openWorldHint`.
- `review_brag_sheet` adds pagination: `limit` (1–100, default 20) and `offset`, returning `{ total, count, offset, hasMore, nextOffset, weeksCovered, items }`.
- Stdio runtime drains the tool queue and flushes outbound writes on `stdin` close so the final JSON-RPC response is never lost.

### Tests (`test/mcp-server.test.mjs`, full rewrite, 16 cases)

- Asserts `additionalProperties: false` on every input schema.
- Asserts `response_format` is declared on every tool.
- Asserts the camelCase keys on every output schema.
- Adds: strict-mode rejection, JSON output mode round-trip for save and review, pagination (limit + offset + `hasMore`/`nextOffset`).
- Full suite: **123/123 pass**.

### Evaluation suite (`evals/`, renamed from `eval/`)

- `evals/brag-sheet.eval.xml`: 10 `<qa_pair>` entries in the canonical `<evaluation><qa_pair><question/><answer/></qa_pair></evaluation>` format.
- Questions exercise time-window filtering, tag/category/CVE lookup, pagination, save round-trip, and the invalid-category error path.
- Each answer is a single deterministic token derived from the fixture, no chain-of-thought.
- `evals/fixtures/entries.json`: 15 entries (3 in last 7 days, 9 in last 28, 15 in last 84).
- `evals/seed.mjs`: deterministic seeder, path constants updated.

### Brand surface — "zero dependencies" → "MCP-conformant"

- `package.json`: adds `mcpName: "io.github.microsoft/copilot-brag-sheet"`, description swap, `eval/` → `evals/` in `files` entry and `eval:seed` script.
- `plugin.json`, `.claude-plugin/plugin.json`: description swap.
- `README.md` and `docs/index.html`: trust-ribbon + JSON-LD description updated.
- `skills/brag-sheet/SKILL.md`, `extension.mjs`, `CONTRIBUTING.md`, `ROADMAP.md`: language softened to reflect one runtime dependency on the official SDK.
- `docs/cross-engine-decisions.md` §1: fully rewritten to explain the reversal; §§2–5 untouched.
- `docs/cross-engine-spec.md`: open question 1 marked resolved; lib-only zero-dep claim narrowed.
- `docs/blog-post-devto.md`: lessons-learned narrative narrowed to `lib/`.

### What did NOT change

- `lib/` modules remain pure Node.js with no runtime dependencies.
- `extension.mjs` only updated for JSDoc voice; behavior unchanged.
- No version bump, no merge, no migration of consumers.

## Verification

| Check | Result |
| --- | --- |
| `npm test` (full suite) | 123 / 123 pass |
| MCP test sub-suite | 16 / 16 pass |
| `node evals/seed.mjs` | Writes 15 entries from fixture |
| Manual JSON-RPC smoke test (initialize + tools/list + tools/call across all 3 tools, both response_formats, strict-mode rejection, pagination) | All assertions pass; `structuredContent` populated for every successful call |
| `npm pack --dry-run` | 40.3 kB packed / 136.6 kB unpacked / 22 files |

## Compatibility

- Wire format unchanged: still JSON-RPC 2.0 over stdio.
- Tool names unchanged: `save_to_brag_sheet`, `review_brag_sheet`, `generate_work_log`.
- Existing required input fields unchanged. New fields (`response_format`, `limit`, `offset`) are optional with sensible defaults.
- Output payloads now structured (`structuredContent`) **and** mirrored in `content[0].text`. Markdown output is the default and is byte-identical to prior shape.
- `.claude-plugin/plugin.json` mcpServers key remains `"brag-sheet"` (host-side identifier; unchanged).
