### PR TITLE
docs: add AGENTS.md + testing & security guidance for AI agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,526 @@
+# AGENTS.md
+
+> **README for AI coding agents.** If you're a human looking for setup or
+> usage instructions, read [`README.md`](README.md) instead. This file is the
+> dedicated place where Claude Code, Copilot CLI, Codex, Cursor, Jules, Amp,
+> and friends find the context they need to be productive on this repo
+> without re-deriving it from grep.
+>
+> **Format:** [agents.md](https://agents.md/) — used by 60k+ open-source
+> projects and stewarded by the Agentic AI Foundation under the Linux
+> Foundation. The closest `AGENTS.md` to the file you're editing wins;
+> explicit prompts override everything.
+
+---
+
+## 1. Project overview
+
+`copilot-brag-sheet` is a [GitHub Copilot CLI](https://docs.github.com/en/copilot/github-copilot-in-the-cli)
+extension that silently records work as it happens — files edited, PRs
+created, git actions, manual brag entries — into structured local JSON so a
+developer has receipts at performance review time instead of a blank page.
+It ships as a [`joinSession()`](https://docs.github.com/en/copilot/customizing-copilot/extending-copilot-with-mcp-and-extensions)
+extension installed into `~/.copilot/extensions/copilot-brag-sheet/`,
+runs entirely on the user's machine, has **zero runtime dependencies**, and
+emits **zero telemetry**. The user-facing pitch is:
+
+> Turn vague *what did I do?* into evidence-backed impact statements —
+> automatically, every Copilot CLI session.
+
+Public repo: <https://github.com/microsoft/copilot-brag-sheet> ·
+npm: [`copilot-brag-sheet`](https://www.npmjs.com/package/copilot-brag-sheet) ·
+landing: <https://microsoft.github.io/copilot-brag-sheet/>.
+
+---
+
+## 2. Architecture map
+
+```
+Copilot CLI host  ──spawns──▶  extension.mjs (joinSession)
+                                    │
+                                    ├── hooks: onSessionStart / onUserPromptSubmitted /
+                                    │           onPostToolUse / onSessionEnd /
+                                    │           session.shutdown
+                                    │
+                                    ├── tools: save_to_brag_sheet
+                                    │          review_brag_sheet
+                                    │          generate_work_log
+                                    │
+                                    └── delegates to lib/* (pure Node, no SDK coupling)
+                                            │
+                                            ▼
+                              JSON records on disk (atomic writes)
+                              ~/AppData/Local/copilot-brag-sheet/  (Windows)
+                              ~/Library/Application Support/copilot-brag-sheet/  (macOS)
+                              ~/.local/share/copilot-brag-sheet/  (Linux, XDG)
+                                            │
+                                            ▼
+                              optional: git commit/push to private repo
+```
+
+**Entry points** (start here):
+
+| File | Role |
+|---|---|
+| [`extension.mjs`](extension.mjs) | The only file that imports `@github/copilot-sdk/extension`. Wires hooks and tools to `lib/*`. **All Copilot-specific glue lives here and nowhere else.** |
+| [`bin/install.mjs`](bin/install.mjs) | `npm i -g copilot-brag-sheet && copilot-brag-sheet` — copies package files into `~/.copilot/extensions/` and runs setup. |
+| [`bin/setup.mjs`](bin/setup.mjs) | Interactive wizard: presets, git backup, output path. Non-TTY exits cleanly (CI-safe). |
+| [`install.sh`](install.sh) / [`install.ps1`](install.ps1) | Curl-pipe-bash installers. Cross-platform CI-tested on PS 5.1 and pwsh 7. |
+
+**Core library** (`lib/`) — zero deps, pure Node, Copilot-agnostic:
+
+| Module | Responsibility | Key exports |
+|---|---|---|
+| [`paths.mjs`](lib/paths.mjs) | OS-native data dir + path helpers; respects `WORK_TRACKER_DIR` / `XDG_DATA_HOME` / `LOCALAPPDATA`. | `detectDataDir`, `detectBragSheetPath`, `detectGitConfig`, `ensureDir` |
+| [`config.mjs`](lib/config.mjs) | Loads `config.json`, merges with defaults, surfaces `microsoft` preset context. | `loadConfig`, `getAllCategoryIds`, `isValidCategory`, `buildUserContext`, `DEFAULT_CONFIG` |
+| [`lock.mjs`](lib/lock.mjs) | Cross-platform PID-aware file lock (`O_EXCL` create + stale-process detection). | `withFileLock` |
+| [`storage.mjs`](lib/storage.mjs) | Atomic JSON writes (tmp → fsync → rename), shard-aware reads, `updateRecord` under lock. | `atomicWriteJSON`, `writeRecord`, `readRecords`, `updateRecord`, `logError` |
+| [`records.mjs`](lib/records.mjs) | Record factories, sanitization, dedupe, file-path normalization. | `createSessionRecord`, `createEntryRecord`, `addFileToRecord`, `sanitize`, `dedupeArray` |
+| [`render.mjs`](lib/render.mjs) | JSON records → grouped Markdown (`work-log.md`, review summaries). | `weekOf`, `renderMarkdown`, `renderReviewSummary` |
+| [`git-backup.mjs`](lib/git-backup.mjs) | Optional git init / commit / push of the data dir; sessions excluded via auto-generated `.gitignore`. | `ensureGitRepo`, `addRemote`, `hasRemote`, `backupToGit`, `createGitRunner` |
+
+**Records on disk** (sharded by `YYYY/MM`):
+
+```
+<dataDir>/
+├── sessions/2026/05/2026-05-01T12-34-56.789Z_<sessionId>.json
+├── entries/2026/05/2026-05-01T12-35-10.000Z_<uuid>.json
+├── config.json                 # user config (preset, categories, git)
+├── work-log.md                 # generated; safe to delete and regenerate
+├── errors.log                  # appended by logError; never throws
+└── .git/                       # only if git backup enabled
+```
+
+Full schema reference for each record shape is in [`lib/records.mjs`](lib/records.mjs)
+(`createSessionRecord` / `createEntryRecord`). **JSON is the source of
+truth; Markdown is regenerated.**
+
+---
+
+## 3. Build / test / lint commands
+
+This repo has **no build step** (ESM runs directly on Node 18+) and **no
+linter configured** today. The full toolbox is `node --test`.
+
+```bash
+# Run all 107 tests (ubuntu/macos/windows × Node 18/20/22 in CI)
+npm test
+
+# Run a single test file
+node --test test/storage.test.mjs
+
+# Run a single test by name pattern
+node --test --test-name-pattern="atomic" test/storage.test.mjs
+
+# Validate the npm tarball will publish a working package
+npm pack --dry-run
+```
+
+PowerShell-friendly variants (Windows users):
+
+```powershell
+# From repo root
+npm test
+node --test test\storage.test.mjs
+
+# Run the local install end-to-end into a scratch COPILOT_HOME
+$env:COPILOT_HOME = "$env:TEMP\copilot-home-test"
+.\install.ps1
+Get-ChildItem $env:COPILOT_HOME\extensions\copilot-brag-sheet
+```
+
+**There is no `npm install` step for contributors** — the repo has zero
+runtime dependencies and no devDependencies. Cloning and running
+`npm test` Just Works. If a future change ever requires `npm install`,
+that's a red flag — see §10.
+
+---
+
+## 4. Code conventions
+
+These are non-negotiable. Most of them encode hard-won lessons (CI failures,
+real bug reports). Don't change them without an issue and discussion first.
+
+- **Zero runtime dependencies.** `package.json` has no `dependencies`. Only
+  `peerDependencies` (the Copilot SDK, declared `optional`). If you reach
+  for npm, stop and use `node:` built-ins.
+- **ESM only.** `.mjs` everywhere, `"type": "module"` in `package.json`.
+  No CommonJS. No transpilation. Use `node:`-prefixed imports
+  (`node:fs`, `node:path`, `node:crypto`, `node:child_process`).
+- **Node 18+ baseline.** No optional chaining gymnastics, but also no
+  features newer than what Node 18 LTS supports. Test matrix is
+  18 / 20 / 22.
+- **Atomic JSON writes.** All disk writes go through
+  [`atomicWriteJSON`](lib/storage.mjs) (`open` → `writeFile` → `fsyncSync` →
+  `closeSync` → `renameSync`, with `unlinkSync` cleanup on failure).
+  See `lib/storage.mjs:216-244`. The same pattern is duplicated for text in
+  `extension.mjs:118-135` (`atomicWriteText`) — keep them in sync.
+- **File locking for concurrent writers.** Multi-process safety uses
+  [`withFileLock`](lib/lock.mjs) — `O_EXCL` create + PID written into the
+  lockfile + 30s stale detection via `process.kill(pid, 0)`. Use it any
+  time you mutate an existing record (`updateRecord` already does).
+- **Sanitization, always.** Free-text from the LLM/user goes through
+  [`sanitize()`](lib/records.mjs) (`lib/records.mjs:50-71`): newlines collapsed,
+  `WEEKLY_ENTRIES_*` markers stripped, leading `#`s removed, pipes
+  escaped, hard-truncated to 500 chars. Never write raw prompt text into
+  a record.
+- **Errors are logged, not thrown.** Every hook handler and tool handler
+  is wrapped in `try { ... } catch (err) { logError(dataDir, "<context>", err); }`.
+  `logError` itself never throws (`lib/storage.mjs:305-313`). The
+  extension is a side-channel; **a logging failure must never break the
+  user's session.**
+- **No `console.log` in `extension.mjs`.** Stdout is the host's JSON-RPC
+  channel. Use `await session.log(text, { ephemeral: true })` for
+  user-facing messages and `process.stderr.write(...)` (gated on
+  `BRAG_SHEET_DEBUG=1`) for debug output.
+- **Cross-platform path handling.** Always `path.join`/`path.resolve`,
+  never string concatenation. `addFileToRecord` normalizes to forward
+  slashes for storage (`lib/records.mjs:118-120`) so output is
+  platform-stable.
+- **Markdown is generated, never edited.** The `<!-- WEEKLY_ENTRIES_START -->`
+  / `<!-- WEEKLY_ENTRIES_END -->` markers in `work-log.md` are reserved.
+  Anything outside them is preserved by users; everything inside is
+  rewritten on each `generate_work_log`.
+- **No new lib modules without updating `release.yml`.** The release
+  workflow validates the npm tarball against an explicit allow-list (see
+  `.github/workflows/release.yml:57-82`). New `lib/foo.mjs` requires both
+  `package.json` `files` and `release.yml` `required` array updates, or
+  the publish fails.
+
+---
+
+## 5. Testing strategy
+
+Current state: **107 tests, all green, run cross-platform in CI.** Counts
+per file (verify with `Select-String -Pattern '^\s*it\('`):
+
+| File | Tests | Covers |
+|---|---:|---|
+| `test/extension.test.mjs` | 34 | Pure helpers extracted from `extension.mjs` (record lifecycle, file tracking, brag detection, PR extraction). Hooks themselves are not unit-tested — see below. |
+| `test/git-backup.test.mjs` | 18 | `ensureGitRepo`, `addRemote`, `backupToGit` with a mocked `git` runner. |
+| `test/render.test.mjs` | 14 | Markdown rendering, week boundaries (UTC), category grouping, escaping. |
+| `test/storage.test.mjs` | 10 | Atomic writes, shard layout, filter semantics, update flow. |
+| `test/config.test.mjs` | 9 | Default merge, microsoft preset, category resolution. |
+| `test/records.test.mjs` | 8 | Record factories, sanitization, file-path dedup. |
+| `test/paths.test.mjs` | 7 | Per-platform data dir resolution, env-var overrides. |
+| `test/lock.test.mjs` | 7 | Lock acquisition, stale-PID cleanup, contention. |
+| **Total** | **107** | |
+
+**What's covered:**
+
+- Pure helpers in every `lib/` module.
+- Storage layer: atomic writes survive simulated failures; shard
+  filtering works; bad JSON files are skipped, not fatal.
+- Locking: stale locks (dead PID) are cleaned up; contention surfaces
+  `EEXIST` correctly.
+- Git backup: end-to-end with `execFile` mocked; covers commit/push,
+  no-changes path, missing remote, init failure.
+
+**What's intentionally NOT covered (yet):**
+
+- Hooks firing inside a real Copilot SDK runtime — `extension.mjs`
+  imports from `@github/copilot-sdk/extension`, which only resolves
+  inside the host. We test the pure helpers; integration is currently
+  manual smoke testing.
+- `bin/setup.mjs` happy path (interactive prompts).
+- `install.sh` / `install.ps1` — covered by **install-smoke** matrix in
+  CI (Linux, macOS, Windows × PS 5.1 and pwsh 7+) but not by `node --test`.
+- Real-process orphan recovery (we cover the `isProcessAlive` branch in
+  unit tests, not the cross-process scenario).
+
+**Roadmap to better coverage** lives in [`docs/testing-strategy.md`](docs/testing-strategy.md):
+mock-host hooks tests using a fake `joinSession` shim, plus subprocess
+nightlies that drive `node extension.mjs` end-to-end through stdio.
+
+When adding tests:
+
+- Use `node:test`'s `describe` / `it`, `node:assert/strict`, and
+  `mkdtempSync(join(tmpdir(), "..."))` for isolation.
+- Clean up in `after()` hooks; tests must be parallel-safe.
+- Mirror the source filename: `lib/foo.mjs` → `test/foo.test.mjs`.
+- For anything that touches `process` or `git`, take an injectable
+  function parameter so the test can mock it (see
+  `createGitRunner` in `lib/git-backup.mjs:34-46` for the pattern).
+
+---
+
+## 6. Security & privacy posture
+
+> **One-line summary:** Local-first, zero telemetry, atomic writes,
+> sessions/ excluded from any optional git backup, no secret redaction
+> *yet* (planned). Full threat model in [`docs/security-model.md`](docs/security-model.md).
+
+What we **DO** defend against:
+
+- **Crash mid-write** → atomic JSON writes (tmp + fsync + rename) guarantee
+  either the old version or the complete new version, never a half-written
+  one. OneDrive/iCloud-safe.
+- **Concurrent writers** → `withFileLock` with PID + stale detection.
+- **Process death** → `session.shutdown` synchronous emergency-save
+  (`extension.mjs:558-571`), plus `recoverOrphans` on next boot
+  (`extension.mjs:94-116`) marks abandoned sessions instead of leaving
+  them `active` forever.
+- **Network egress** → there is none. The only network call is the
+  optional `git push` if (and only if) the user explicitly opted in via
+  the setup wizard *and* configured a remote.
+- **Markdown injection** → `sanitize()` strips reserved markers, escapes
+  pipes, removes leading `#`, and truncates to 500 chars before any text
+  hits `work-log.md`.
+
+What we **do NOT** currently defend against:
+
+- **Secret leakage in records.** If a user types an API key into a
+  prompt and the LLM writes it into `summary`, it ends up in the JSON.
+  Redaction is on the roadmap.
+- **Filesystem snooping by other local users.** Records inherit the OS
+  default permissions of the data directory. We don't `chmod 600`.
+- **Malicious extensions running in the same Copilot CLI process.**
+  We trust the host.
+
+If your change touches data flow, redaction, or any new I/O surface,
+update [`docs/security-model.md`](docs/security-model.md) in the same PR.
+
+---
+
+## 7. Release process
+
+This is fully automated by `.github/workflows/release.yml`. Don't hand-publish.
+
+```bash
+# 1. Bump version + add CHANGELOG entry in a normal PR
+#    Edit:  package.json  →  "version": "1.x.y"
+#    Edit:  CHANGELOG.md  →  add ## [1.x.y] — YYYY-MM-DD section
+#    Follow https://keepachangelog.com/ format. SemVer rules:
+#      - patch:   bug fix, doc, polish
+#      - minor:   new feature, backward compat
+#      - major:   breaking schema/behavior change
+
+# 2. Merge the PR (squash). CI must be green across 3 OS × 3 Node versions.
+
+# 3. From an up-to-date main, tag and push:
+git checkout main && git pull
+git tag v1.x.y
+git push origin v1.x.y
+```
+
+What `release.yml` does on the tag:
+
+1. Reruns the full test matrix.
+2. Asserts `tag == package.json.version` (`release.yml:43-50`).
+3. Validates the npm tarball includes every required file
+   (`release.yml:52-82`).
+4. Extracts the matching `CHANGELOG.md` section.
+5. Creates the GitHub Release.
+6. Runs `npm publish --provenance --access public` using `NPM_TOKEN`.
+7. Skips publish if the tag is a pre-release (e.g. `v1.0.0-rc1`).
+
+**Verify after release:** open
+<https://www.npmjs.com/package/copilot-brag-sheet>, confirm the new
+version is published, and run `npm install -g copilot-brag-sheet@latest`
+in a scratch shell to smoke-test the end-to-end install.
+
+**Trusted Publishing** (OIDC) migration is on the [roadmap](ROADMAP.md#priority-2--polish-after-distribution-proven).
+Until then, the `_npmUser` is whoever holds the `NPM_TOKEN`, not
+`author: Microsoft`.
+
+---
+
+## 8. Distribution channels
+
+| Channel | Status | Surface |
+|---|---|---|
+| **npm** | ✅ live (`copilot-brag-sheet`) | `npm i -g copilot-brag-sheet && copilot-brag-sheet` runs `bin/install.mjs`. |
+| **`install.sh` / `install.ps1`** | ✅ live | One-line curl-pipe-bash from `raw.githubusercontent.com/...`. CI-tested on PS 5.1 + pwsh 7 + bash. |
+| **awesome-copilot skill** | ✅ live | [`SKILL.md`](skills/brag-sheet/SKILL.md) is mirrored in [github/awesome-copilot](https://github.com/github/awesome-copilot) (PR #1428). The skill is the prompt; this repo is the prompt **plus** the deterministic capture. |
+| **Claude Code plugin** | 🟡 planned | Tracked in [`docs/cross-engine-spec.md`](docs/cross-engine-spec.md). Will reuse `lib/*` unchanged via a thin Claude adapter. |
+| **MCP server** | 🟡 planned | `mcp-server.mjs` will expose the same three tools to any MCP-compatible host (Cursor, VS Code, Codex, Copilot CLI). |
+| **`copilot plugin install`** | 🚫 blocked upstream | This is a `joinSession()` extension, not an MCP plugin — needs [github/copilot-cli#3023](https://github.com/github/copilot-cli/issues/3023). Don't try to register it under `~/.copilot/plugins/`. |
+
+Don't add new distribution channels (e.g. Homebrew, scoop, winget)
+without first checking the [ROADMAP](ROADMAP.md) — the priority is
+proving distribution conversion before fanning out further.
+
+---
+
+## 9. Repo navigation
+
+| Path | Purpose | Modify when... |
+|---|---|---|
+| `extension.mjs` | Copilot CLI entry point: hooks + tools. **Only file that imports the SDK.** | Adding a hook or tool. Wiring new lib functionality into the host. |
+| `lib/paths.mjs` | OS-native data dir; env-var overrides. | Adding a new path target or platform. |
+| `lib/config.mjs` | Default config + presets + category management. | Adding a preset or default category. |
+| `lib/lock.mjs` | PID-aware file lock. | Don't, unless you have a strong reason. Battle-tested. |
+| `lib/storage.mjs` | Atomic JSON I/O, shard reads, `updateRecord`. | Adding a new record type or query filter. |
+| `lib/records.mjs` | Record factories, `sanitize`, `addFileToRecord`. | Changing the record schema (and read §10 first). |
+| `lib/render.mjs` | Records → Markdown. Reserved markers live here. | Changing the work-log Markdown layout. |
+| `lib/git-backup.mjs` | Optional git init/commit/push of data dir. | Adding remote types, fixing git edge cases. |
+| `bin/install.mjs` | Post-`npm-i` wizard launcher. Copies pkg → `~/.copilot/extensions/`. | Changing the install layout or required-files list. |
+| `bin/setup.mjs` | Interactive setup wizard. Non-TTY-safe. | Adding a config field, preset, or onboarding step. |
+| `install.sh` / `install.ps1` | Curl-pipe-bash installers. | Cross-platform install behavior. PR must include CI smoke updates. |
+| `plugin.json` | Plugin manifest (name, source, license). **No `version` field** — `package.json` is source of truth. | Renaming or relicensing. |
+| `package.json` | npm metadata, version, `files` allow-list, `bin` map. | Version bumps, adding a published file. |
+| `test/*.test.mjs` | `node:test` suites — one per `lib/` module + `extension.test.mjs` for helpers. | Always, when changing behavior. |
+| `.github/workflows/ci.yml` | Test matrix + install-smoke matrix. | Adding a platform, Node version, or smoke check. |
+| `.github/workflows/release.yml` | Tag-triggered publish + tarball validation. | Adding a `lib/` file (update `required` array) or changing publish flow. |
+| `skills/brag-sheet/SKILL.md` | The LLM-facing prompt. Used by awesome-copilot mirror. | Changing brag-trigger behavior or prompt guidance. |
+| `docs/cross-engine-spec.md` | MCP + Claude plugin design doc. | Cross-engine work. |
+| `docs/testing-strategy.md` | Test coverage map + roadmap (mock host, subprocess tests). | When you add tests or want to. |
+| `docs/security-model.md` | Threat model, data flow, redaction plan. | Any change touching new I/O, data fields, or trust boundaries. |
+| `docs/backfill-guide.md` | User guide for retro-importing past work. | User-visible backfill behavior. |
+| `docs/blog-post-devto.md` | Marketing draft. | Releases / launches. |
+| `ROADMAP.md` | Prioritized backlog. **Read before proposing big work.** | When shipping a roadmap item or proposing a new one. |
+| `CHANGELOG.md` | Per-version notes. | Every user-visible change. |
+| `CONTRIBUTING.md` | Human contributor guide (project structure, code style). | Major repo-level convention changes. |
+| `README.md` | Human-facing pitch + install + usage. | User-visible behavior. Keep the strong voice. |
+| `demo/` | Marketing assets (GIF, video, slides). Not tracked in tarball. | Launch material. |
+
+---
+
+## 10. Things to NEVER do
+
+> If you're tempted to do any of these, **stop and open an issue first.**
+
+1. **Add a runtime dependency.** Zero deps is a feature. It's the answer
+   to half the install bugs in `CHANGELOG.md`. If you need
+   functionality, write it in `lib/` against `node:` built-ins. There is
+   no `npm install` for contributors and we want to keep it that way.
+2. **Write JSON non-atomically.** Always go through
+   [`atomicWriteJSON`](lib/storage.mjs:216). A `writeFileSync` straight to
+   the final path will eventually corrupt the user's history during a
+   crash or OneDrive sync.
+3. **Capture telemetry of any kind.** No analytics, no usage pings, no
+   crash reporting, no "anonymous opt-in." This is a load-bearing
+   promise on the README. If you want to know how many people use the
+   tool, read npm's download counter.
+4. **Change a record schema field without a migration path.** Old
+   `sessions/2025/*/...json` records still need to read cleanly. If you
+   rename a field, also handle the old name on read (or write a
+   one-shot upgrade in `lib/storage.mjs:readRecords`). Tests in
+   `test/storage.test.mjs` should cover both shapes.
+5. **`console.log` from `extension.mjs`.** Stdout is the host's JSON-RPC
+   channel. You will corrupt the agent's transcript. Use
+   `session.log(...)` for user-visible messages and stderr (gated on
+   `BRAG_SHEET_DEBUG=1`) for debug.
+6. **Add an `update-notifier` or any in-process "you should update" UI.**
+   Same reason as above — stdio is sacred. Plus it would break zero
+   deps. Users update via `npm update -g`.
+7. **Use `npm install` for a runtime dep.** See #1. There are exactly
+   zero approved exceptions today.
+8. **Bypass `sanitize()` when persisting LLM/user text.** Reserved
+   markers, pipe chars, leading `#`, and length must always be filtered.
+   See `lib/records.mjs:50-71`.
+9. **Ship a `lib/` file without updating `package.json`'s `files` array
+   AND `release.yml`'s `required` array.** The publish job will fail
+   the tarball check, but only after you've cut the tag.
+10. **Bump version without a `CHANGELOG.md` entry.** `release.yml`
+    extracts release notes from the changelog (`release.yml:84-92`). No
+    section ⇒ empty release notes ⇒ confused users.
+11. **Edit `work-log.md` between the `WEEKLY_ENTRIES_*` markers.** Anything
+    inside is rewritten on next `generate_work_log`. Anything outside is
+    preserved. Touching the markers themselves breaks the next render.
+12. **Add a runtime dependency.** Yes, this is listed twice. That's how
+    important it is.
+
+---
+
+## 11. Where to find more
+
+- [`README.md`](README.md) — user pitch, install, examples, FAQ. Match its voice.
+- [`CONTRIBUTING.md`](CONTRIBUTING.md) — human contributor guide; some overlap with this doc.
+- [`ROADMAP.md`](ROADMAP.md) — prioritized backlog. **Read before proposing new work.**
+- [`CHANGELOG.md`](CHANGELOG.md) — per-version notes. Reflects what shipped, why, and which bugs each release fixed.
+- [`SECURITY.md`](SECURITY.md) — Microsoft's standard responsible-disclosure pointer.
+- [`docs/testing-strategy.md`](docs/testing-strategy.md) — current coverage + plan to add mock-host hooks tests and subprocess nightly E2E.
+- [`docs/security-model.md`](docs/security-model.md) — threat model, data flow, redaction plan.
+- [`docs/cross-engine-spec.md`](docs/cross-engine-spec.md) — MCP + Claude Code plugin design.
+- [`docs/backfill-guide.md`](docs/backfill-guide.md) — user-facing how-to for back-filling history.
+- [`skills/brag-sheet/SKILL.md`](skills/brag-sheet/SKILL.md) — the LLM-facing prompt, also mirrored in awesome-copilot.
+
+---
+
+## 12. Quick task playbook
+
+Five-step recipes. Pick the one that matches your task; deviate only with reason.
+
+### How to fix a bug
+
+1. Reproduce it. Add a failing test in the matching `test/<module>.test.mjs`
+   first. Confirm it fails: `node --test test/<module>.test.mjs`.
+2. Find the offending function via `grep` / `lsp` (`workspaceSymbol`).
+   Bug fixes almost always live inside one `lib/*` module.
+3. Fix it. Keep the change surgical — don't drag in unrelated cleanups.
+4. Run the full suite (`npm test`) — must stay 107+/0 across the matrix.
+5. PR with a `CHANGELOG.md` entry under `## [Unreleased]` → `### Fixed`.
+   Reference the issue. CI must be green before merge.
+
+### How to add a feature
+
+1. Check [`ROADMAP.md`](ROADMAP.md). If it isn't there, open an issue
+   first to confirm priority — we are aggressive about saying no.
+2. Decide the layer:
+   - **New tool / hook behavior** → `extension.mjs` + a new function in
+     the relevant `lib/*` module. Tests in
+     `test/extension.test.mjs` for the helper logic.
+   - **New record field** → `lib/records.mjs` (factory) + read-time
+     compatibility in `lib/storage.mjs` + a render path in
+     `lib/render.mjs`. **Old records must still read.** See §10 #4.
+   - **New CLI / install behavior** → `bin/setup.mjs` or
+     `install.{sh,ps1}` + matching CI smoke step in `ci.yml`.
+3. Add tests *first* (TDD-friendly here — the suite is fast). Mirror the
+   source filename. Use `mkdtempSync` for isolation.
+4. Update [`README.md`](README.md) only if the feature is user-visible
+   and shipping. Match the existing voice.
+5. PR with `## [Unreleased]` → `### Added` entry in `CHANGELOG.md` and a
+   ROADMAP item ticked or removed. Don't bump `version` in the same PR
+   as a feature — that's a separate release PR.
+
+### How to ship a release
+
+1. From `main`, open a PR titled `release: vX.Y.Z`. In that PR:
+   - Bump `package.json.version`.
+   - Move `## [Unreleased]` → `## [X.Y.Z] — YYYY-MM-DD` in `CHANGELOG.md`.
+   - Add a fresh empty `## [Unreleased]` heading.
+2. Merge the PR (squash). Wait for CI green on `main`.
+3. From up-to-date `main`: `git tag vX.Y.Z && git push origin vX.Y.Z`.
+4. Watch `release.yml`. It validates tag/version match, validates the
+   tarball, extracts changelog notes, creates the GitHub Release, and
+   `npm publish --provenance`s.
+5. Verify <https://www.npmjs.com/package/copilot-brag-sheet> shows the
+   new version and `npm i -g copilot-brag-sheet@latest` works in a
+   scratch shell.
+
+### How to add a new lib module
+
+1. Create `lib/<name>.mjs` — pure Node, zero deps, `node:`-prefixed
+   imports, `export`ed functions only.
+2. Create `test/<name>.test.mjs` mirroring it.
+3. Add the file to `package.json`'s `files` array.
+4. Add the file to `.github/workflows/release.yml`'s `required` array
+   (the publish-time tarball check). Both are required or the next
+   publish silently ships a broken package.
+5. Wire it into `extension.mjs` only if the host needs it; otherwise
+   it's a shared utility consumed by hooks/tools.
+
+### How to investigate a user-reported install failure
+
+1. Reproduce on the same OS/shell. The CI matrix covers ubuntu/macos +
+   Windows on PS 5.1 *and* pwsh 7+ — start by running the matching
+   `install-smoke-*` job locally:
+   ```powershell
+   $env:COPILOT_HOME = "$env:TEMP\copilot-home-test"
+   .\install.ps1   # or bash ./install.sh on *nix
+   ```
+2. Check `~/.copilot/extensions/copilot-brag-sheet/` for the expected
+   layout (matches `release.yml:46-55`).
+3. Repro under `BRAG_SHEET_DEBUG=1` and read the stderr trail.
+4. If it's a host-side issue, link [github/copilot-cli#3023](https://github.com/github/copilot-cli/issues/3023)
+   and any related upstream tracker.
+5. Fix in `install.{sh,ps1}` or `bin/install.mjs` *and* extend the
+   `install-smoke-*` matrix to prevent regression. (See `ci.yml:67-126`
+   for the PS 5.1 + pwsh 7 split — that pattern caught the v1.0.1 bug.)
+
+---
+
+_Last updated: 2026-05. Keep this file living. If you discover a
+convention not listed here, add it. If a "never" doesn't apply anymore,
+delete it with explanation in the PR._

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -1,0 +1,365 @@
+# Security Model
+
+> Companion doc to [`AGENTS.md`](../AGENTS.md). Read this whenever you're
+> about to add a new I/O surface, change what's persisted, or wire in
+> network egress. For Microsoft's responsible-disclosure pointer, see
+> [`SECURITY.md`](../SECURITY.md).
+
+---
+
+## TL;DR
+
+`copilot-brag-sheet` is a **local-first, zero-telemetry, zero-network**
+extension. The only data that ever leaves the user's machine is the
+optional `git push` they explicitly opt into during setup, to a remote
+they themselves chose. Records on disk are written atomically; concurrent
+writers are serialized via PID-aware file locks; LLM output is sanitized
+before persistence.
+
+What we do **NOT** defend against today (and you should know about):
+secret leakage from prompts/LLM output (redaction is on the roadmap),
+filesystem snooping by other local users on the same machine, and
+malicious co-resident extensions inside the Copilot CLI process. We
+inherit the host's trust model.
+
+---
+
+## Threat model
+
+We use a deliberately small STRIDE-lite framing.
+
+| Threat | In scope? | Mitigation |
+|---|---|---|
+| **Spoofing** the data dir (env-var injection) | ✅ | `WORK_TRACKER_DIR` is honored as the user explicitly opts into it via setup. We document this. The wizard is gated on `process.stdin.isTTY` — non-interactive callers must hand-edit `config.json`. |
+| **Tampering** with records mid-write | ✅ | Atomic writes (`tmp → fsync → rename`). On crash you keep either the previous version or the complete new one — never half. See [`lib/storage.mjs:216-244`](../lib/storage.mjs). |
+| **Repudiation** of brag entries | ❌ out of scope | This is a personal log, not an audit log. Don't use it where authenticity matters. |
+| **Information disclosure** to network | ✅ | No outbound HTTP. The only network call is `git push`, only when both `gitConfig.enabled` AND `gitConfig.push` are true AND a remote exists ([`lib/git-backup.mjs:151-164`](../lib/git-backup.mjs)). |
+| **Information disclosure** to disk (secrets in records) | 🟡 partial | `sanitize()` strips structure but does **not** redact secrets. See "Known gaps" below. |
+| **Information disclosure** to other local users | 🟡 partial | Records inherit OS default file permissions on the data dir. We do not `chmod 600`. Single-user laptops are fine; shared boxes aren't. |
+| **Denial of service** (lockfile starvation) | ✅ | `withFileLock` has a 5s default timeout and stale-PID cleanup ([`lib/lock.mjs:94-130`](../lib/lock.mjs)). A dead process can't hold a lock forever. |
+| **Elevation of privilege** | ❌ | The extension runs as the user. There is no privileged code path. |
+| **Supply-chain attack on `@github/copilot-sdk`** | ❌ inherited | Declared as `peerDependencies.optional`. We trust whatever the host injects. |
+| **Supply-chain attack on this package on npm** | ✅ | Releases are tag-triggered + provenance-signed (`npm publish --provenance`). `_npmUser` ↔ `author: Microsoft` chain-of-trust gap is tracked under [ROADMAP P2 — Trusted Publishing migration](../ROADMAP.md). |
+
+---
+
+## Data flow
+
+```
+┌─────────────────┐      stdin/stdout         ┌──────────────────────┐
+│  Copilot CLI    │ ◀───────JSON-RPC────────▶ │   extension.mjs      │
+│  host process   │                           │   (joinSession)      │
+└─────────────────┘                           └──────────┬───────────┘
+                                                         │
+                            tool args / hook input       │
+                                                         ▼
+                                              ┌──────────────────────┐
+                                              │   sanitize()         │  ← lib/records.mjs
+                                              │   (strip markers,    │
+                                              │    pipes, headings,  │
+                                              │    cap 500 chars)    │
+                                              └──────────┬───────────┘
+                                                         │
+                                                  validated record
+                                                         │
+                                                         ▼
+                                              ┌──────────────────────┐
+                                              │   atomicWriteJSON    │  ← lib/storage.mjs
+                                              │   (tmp + fsync +     │
+                                              │    rename)           │
+                                              └──────────┬───────────┘
+                                                         │
+                                                         ▼
+                                              ┌──────────────────────┐
+                                              │  <dataDir>/          │
+                                              │   sessions/YYYY/MM/  │
+                                              │   entries/YYYY/MM/   │
+                                              │   config.json        │
+                                              │   work-log.md        │
+                                              │   errors.log         │
+                                              └──────────┬───────────┘
+                                                         │
+                                                         │ optional, opt-in
+                                                         ▼
+                                              ┌──────────────────────┐
+                                              │  git commit / push   │  ← lib/git-backup.mjs
+                                              │  (sessions/* git-    │
+                                              │   ignored — only     │
+                                              │   entries pushed)    │
+                                              └──────────────────────┘
+```
+
+**Trust boundaries (numbered, smallest → largest blast radius):**
+
+1. **LLM tool args → `sanitize()`** — never trust free-form text. Reserved markers, pipes, leading `#`, length all filtered.
+2. **`sanitize()`'d data → atomic write** — content is now structurally safe; durability is now the OS's problem and we use `fsync`.
+3. **Disk → optional git** — entries dir only; sessions are in `.gitignore` to prevent noise *and* to reduce the surface area of what gets pushed remotely (defense in depth even though sessions don't normally contain secrets).
+4. **Git → user-chosen remote** — outside our trust boundary entirely. Users pick GitHub, ADO, self-hosted, whatever.
+
+---
+
+## What we DO defend against
+
+### 1. Crash mid-write
+
+All JSON writes go through `atomicWriteJSON`
+([`lib/storage.mjs:216-244`](../lib/storage.mjs)):
+
+```js
+fd = openSync(tmpPath, "w");
+writeFileSync(fd, JSON.stringify(data, null, 2));
+fsyncSync(fd);
+closeSync(fd);
+renameSync(tmpPath, filePath);
+```
+
+`fsync` forces durability before the rename. `rename` is atomic on
+POSIX and on Windows for same-volume moves. Failure cleans up the tmp
+file. **Result:** OneDrive-, iCloud-, Dropbox-safe. The user never
+loses an existing record because of a crash.
+
+The same pattern is duplicated for text in
+[`extension.mjs:118-135`](../extension.mjs) (`atomicWriteText`) so
+`work-log.md` regeneration is also crash-safe.
+
+### 2. Concurrent writers
+
+Multiple Copilot CLI sessions can overlap on the same data dir.
+`withFileLock` ([`lib/lock.mjs`](../lib/lock.mjs)) wraps every
+`updateRecord`:
+
+- `openSync(lockPath, "wx")` — atomic create, fails with `EEXIST` if held.
+- PID written into the lockfile so a stale lock can be diagnosed.
+- Stale detection: `process.kill(pid, 0)` returns truthy only if the
+  process is alive (or `EPERM`). Dead PIDs ⇒ unlink and retry.
+- 30s default stale window — long enough that a slow GC pause doesn't
+  trip cleanup, short enough that a real crash doesn't wedge anyone.
+
+### 3. Process death without graceful shutdown
+
+Three layers:
+
+- `session.shutdown` handler in [`extension.mjs:558-571`](../extension.mjs)
+  uses **synchronous** `writeRecord` to mark the session
+  `emergency-saved` even if the host kills us mid-stream.
+- `recoverOrphans` on next session start
+  ([`extension.mjs:94-116`](../extension.mjs)) marks any session that's
+  still `active` but whose PID is dead and timestamp >5min old as
+  `orphaned`. The user sees "I crashed" rather than a phantom open
+  session forever.
+- `try { logError(...) } catch {}` everywhere — see "Errors are logged,
+  not thrown" in [`AGENTS.md` §4](../AGENTS.md#4-code-conventions).
+
+### 4. Network egress
+
+There is none, by construction. The only network code path is git push
+in [`lib/git-backup.mjs:151-164`](../lib/git-backup.mjs), gated on
+**three** independent conditions:
+
+1. `gitConfig.enabled === true` (set during setup wizard)
+2. `gitConfig.push === true` (set during setup wizard)
+3. `hasRemote()` returns true (user added a remote)
+
+All three are user-controlled. We never push to a default remote, never
+auto-add a remote, never offer "send error reports" or any analytics.
+
+### 5. Markdown injection
+
+Without sanitization, an attacker (or a chatty LLM) could write
+`WEEKLY_ENTRIES_END\n# Look at me` into a summary and corrupt the
+`work-log.md` markers, hijacking the table layout or breaking the next
+regeneration. `sanitize()` ([`lib/records.mjs:50-71`](../lib/records.mjs)):
+
+- `\r?\n` → `' '` (no newlines in stored summaries).
+- Strips both `WEEKLY_ENTRIES_START` and `WEEKLY_ENTRIES_END` markers.
+- Strips leading `#` so an entry can't masquerade as a heading.
+- Escapes `|` → `\|` so table rows render correctly in `renderMarkdown`.
+- Trims and caps at 500 chars.
+
+Tests cover these in [`test/records.test.mjs`](../test/records.test.mjs)
+and [`test/render.test.mjs`](../test/render.test.mjs) (pipe escaping
+end-to-end).
+
+### 6. Path traversal in tracked file paths
+
+`addFileToRecord` ([`lib/records.mjs:89-116`](../lib/records.mjs)):
+
+- `path.resolve(filePath)` collapses `..` segments to an absolute path.
+- If the resolved path falls inside the repo root, we store a
+  forward-slash-normalized **relative** path. Otherwise we store the
+  absolute path.
+- Skips anything containing `.copilot/session-state` so the agent's own
+  scratch space never ends up in the user's brag log.
+
+This means an LLM can't trick us into recording
+`../../../../etc/passwd` as a tracked file — it'll either become an
+absolute path (visible to the user) or stay outside the repo (unstored
+under repo-relative tracking).
+
+---
+
+## What we do NOT currently defend against
+
+These are documented gaps. Don't be surprised by them; help close them.
+
+### 1. Secret leakage in records
+
+If a user types `My PR #42 used API_KEY=sk-abc123` into a prompt and the
+LLM rolls that into `summary` for a `save_to_brag_sheet` call, we'll
+write `sk-abc123` to disk in `entries/YYYY/MM/...json`. We do not
+currently scan for token patterns.
+
+**Mitigation today:** records are local-only by default; `entries/` is
+included in optional git backup but `sessions/` is not. Even so, a
+distracted user could push a private repo with secrets in it.
+
+**Roadmap:** add a `redactSecrets()` pass between
+`createEntryRecord` and `writeRecord`. Pattern source-of-truth should be
+GitHub's own [secret-scanning regexes](https://docs.github.com/en/code-security/secret-scanning/secret-scanning-patterns)
+where they're publicly documented. Targets to start with:
+
+- GitHub PAT (`ghp_`, `gho_`, `ghu_`, `ghs_`, `ghr_`)
+- OpenAI / Anthropic API keys (`sk-...`, `sk-ant-...`)
+- Azure connection strings (`DefaultEndpointsProtocol=...AccountKey=...`)
+- AWS access keys (`AKIA[0-9A-Z]{16}` + secret pair)
+- Generic `Bearer <jwt>` tokens
+
+Replacement should be `<redacted:type>` so the record stays human-readable.
+
+This is **not** ambitious secret detection (we won't beat GitGuardian).
+It's defense in depth so a casual paste doesn't end up in a quarterly review.
+
+### 2. Filesystem ACLs on the data dir
+
+We `mkdirSync(dataDir, { recursive: true })` but don't set restrictive
+permissions. On a typical single-user laptop this is fine. On a shared
+box, another local user with read access to your home dir can read your
+entries. We are not going to ship a macOS `chmod 700` because it would
+fight users' existing setups, but the option is open if there's demand.
+
+### 3. Co-resident hostile extensions
+
+The Copilot CLI host runs all extensions in the same Node process. A
+hostile extension running alongside us could read our memory, our
+tool-call args, and our records. **We trust the host.** If you don't
+trust the host, don't install anything in `~/.copilot/extensions/`.
+
+### 4. Time-of-check / time-of-use on the lockfile
+
+A determined attacker on the same machine could race us between
+`cleanupStaleLock` (we observe the PID is dead) and `createLock` (we
+re-create). The window is microseconds and the worst-case outcome is a
+duplicate write that the receiving JSON write would clobber atomically
+anyway. We accept this.
+
+### 5. Repository-private branch in git backup
+
+When git push is enabled, `backupToGit` does
+`git pull --rebase` then `git push`. If the user configured a public
+GitHub remote by mistake, their entries become public. We **strongly
+recommend** a private repo in the setup wizard — but we do not check
+remote visibility and cannot, since GitHub APIs aren't available without
+a token we don't ask for.
+
+---
+
+## What goes in `errors.log`
+
+`logError(dataDir, context, error)`
+([`lib/storage.mjs:305-313`](../lib/storage.mjs)) appends:
+
+```
+[2026-05-01T12:34:56.789Z] <context>: <error.message>
+```
+
+It does **not** log:
+
+- Stack traces (deliberately — too noisy, often leak paths).
+- Tool arguments or prompt text.
+- Record contents.
+
+It uses `appendFileSync` (not atomic) because a corrupted error log is
+strictly less bad than throwing out of `logError` itself. The function
+swallows its own errors:
+
+```js
+} catch {
+  // Never throw from logging.
+}
+```
+
+If you're tempted to make this richer, file an issue first. The current
+behavior is intentional.
+
+---
+
+## Privacy posture
+
+- **Telemetry:** none. Ever. Adding any phone-home is in the §10
+  "things to never do" list in [`AGENTS.md`](../AGENTS.md).
+- **Update notifications:** none. The Node `update-notifier` package is
+  a frequent silent telemetry vector AND breaks zero-deps; users update
+  via `npm update -g`.
+- **Crash reporting:** local-only via `errors.log`. We never upload it.
+- **Analytics events:** none.
+- **Default git backup:** OFF. Opt-in only.
+- **Default git push:** OFF, even if backup is enabled. Two separate flags.
+
+The README's `🚫 Zero telemetry` claim is load-bearing. Don't break it.
+
+---
+
+## Why `sessions/` is gitignored
+
+When a user enables git backup, we generate `.gitignore` in the data
+dir ([`lib/git-backup.mjs:6-16`](../lib/git-backup.mjs)) excluding:
+
+```
+sessions/
+errors.log
+*.lock
+*.tmp.*
+```
+
+Two reasons:
+
+1. **Volume.** A heavy Copilot user creates dozens of session records
+   per day. A year of pushes would blow up the remote and rebase performance.
+2. **Defense in depth on data exposure.** Session records contain
+   tracked file paths, repo names, branch names, PRs created, *and the
+   first prompt as `taskDescription`* (see
+   [`extension.mjs:251-262`](../extension.mjs)). That first prompt is
+   the most likely place a user would accidentally paste a secret.
+   Keeping sessions local-only — even when backup is enabled — means
+   that surface area never reaches a remote.
+
+`entries/` is the curated, intentional brag-sheet content. Those
+*should* sync, because that's the whole point of cross-machine backup.
+
+---
+
+## Reporting a vulnerability
+
+Please **do not** open a public GitHub issue. Follow the disclosure
+process documented in [`SECURITY.md`](../SECURITY.md), which routes
+through Microsoft's MSRC.
+
+For non-vulnerability security suggestions (e.g. "we should redact API
+keys"), open a regular issue tagged `security` and link this doc.
+
+---
+
+## Related reading
+
+- [`AGENTS.md`](../AGENTS.md) — agent-facing top-level guide. §6
+  (security & privacy posture) summarizes this doc.
+- [`SECURITY.md`](../SECURITY.md) — Microsoft responsible-disclosure pointer.
+- [`docs/testing-strategy.md`](testing-strategy.md) — what's tested,
+  including the security-relevant `sanitize`, `atomicWriteJSON`, and
+  lockfile behaviors.
+- [`lib/records.mjs`](../lib/records.mjs) — `sanitize()` and
+  `addFileToRecord()` are the two main filtering functions.
+- [`lib/storage.mjs`](../lib/storage.mjs) — atomic write + error logging.
+- [`lib/git-backup.mjs`](../lib/git-backup.mjs) — the only network surface.
+- [`ROADMAP.md`](../ROADMAP.md) — Trusted Publishing migration (P2),
+  redaction (not yet listed; add when starting work).

--- a/docs/testing-strategy.md
+++ b/docs/testing-strategy.md
@@ -1,0 +1,232 @@
+# Testing Strategy
+
+> Companion doc to [`AGENTS.md`](../AGENTS.md). This is the canonical place
+> to look for what we test, what we don't, and how the gaps will close.
+
+---
+
+## Current state — 2026-05
+
+**107 tests, 100% pass rate, 14 suites, ~750ms total runtime.**
+CI matrix: `{ubuntu-latest, macos-latest, windows-latest} × {Node 18, 20, 22}` =
+**9 combinations** running on every PR and `main` push, plus three
+**install-smoke** jobs that exercise the curl-pipe-bash installers
+(Linux/macOS, Windows PS 5.1, Windows pwsh 7+).
+
+Run the suite locally:
+
+```bash
+npm test                                      # all 107
+node --test test/storage.test.mjs             # one file
+node --test --test-name-pattern="atomic"      # one pattern
+```
+
+PowerShell-friendly variants (Windows):
+
+```powershell
+npm test
+node --test test\storage.test.mjs
+node --test --test-name-pattern="atomic" test\storage.test.mjs
+```
+
+No test framework dependency — we use `node:test` and
+`node:assert/strict`. Adding `mocha` / `vitest` / `jest` is a hard no
+(see [`AGENTS.md` §10 — Things to NEVER do](../AGENTS.md#10-things-to-never-do)).
+
+---
+
+## Coverage map by module
+
+| Source module | Test file | Tests | What is covered | What is NOT covered |
+|---|---|---:|---|---|
+| [`lib/paths.mjs`](../lib/paths.mjs) | `test/paths.test.mjs` | 7 | Per-platform data dir resolution (Win/macOS/Linux), env-var overrides (`WORK_TRACKER_DIR`, `XDG_DATA_HOME`, `LOCALAPPDATA`, `WORK_TRACKER_OUTPUT_PATH`), `ensureDir` idempotency. | Symlinked HOME directories. UNC paths on Windows (tracked in [ROADMAP P4](../ROADMAP.md)). |
+| [`lib/config.mjs`](../lib/config.mjs) | `test/config.test.mjs` | 9 | Default config shape, deep-merge with user config, microsoft preset toggles, missing-file fallback, malformed-JSON fallback, category lookup helpers, `buildUserContext` for preset. | Malicious config that injects `__proto__` keys. Unknown preset names (currently silently ignored). |
+| [`lib/lock.mjs`](../lib/lock.mjs) | `test/lock.test.mjs` | 7 | Successful acquire/release, contention (`EEXIST` retries), stale-PID detection (`process.kill(pid, 0)`), lock-file content readback, timeout. | Multi-process contention (we mock PIDs). Filesystem-level locking on network shares (SMB/NFS). |
+| [`lib/storage.mjs`](../lib/storage.mjs) | `test/storage.test.mjs` | 10 | Atomic write (tmp file cleanup on failure), shard layout (`YYYY/MM/<ts>_<id>.json`), shard-bound filtering on `since`/`until`, type/category/repo/tags filters, `updateRecord` merge semantics, `logError` never throws. | Disk-full scenarios. `fsync` failures (we trust the OS). Records with `Date.parse`-invalid timestamps in old data. |
+| [`lib/records.mjs`](../lib/records.mjs) | `test/records.test.mjs` | 8 | `createSessionRecord` + `createEntryRecord` shape, `sanitize()` (newlines, markers, headings, pipes, length cap), `addFileToRecord` dedup + `.copilot/session-state` filtering + repo-relative path normalization. | Case-insensitive dedup on Windows/macOS. Path traversal (`../`) attempts. |
+| [`lib/render.mjs`](../lib/render.mjs) | `test/render.test.mjs` | 14 | `weekOf` UTC consistency including year boundaries, `renderMarkdown` empty/single/multi-week/multi-category cases, session-log opt-in, escaping pipes in tables, ordering newest-first, "Other" bucket for uncategorized, `renderReviewSummary` window filtering. | Internationalized week boundaries (we hardcode UTC). Locale-specific month names. |
+| [`lib/git-backup.mjs`](../lib/git-backup.mjs) | `test/git-backup.test.mjs` | 18 | `ensureGitRepo` init + idempotent reuse, `addRemote`, `hasRemote`, `backupToGit` happy path / no-changes / commit-fail / push-fail, error logging via the injectable runner pattern (`createGitRunner`). | Real `git` binary execution (we mock). Auth failures on push. Detached HEAD states. Repos with submodules. |
+| [`extension.mjs`](../extension.mjs) | `test/extension.test.mjs` | 34 | Pure helpers extracted from the entry point: session lifecycle (active/finalized/orphaned/emergency-saved), file tracking (edit/create classification, dedup, `.copilot/session-state` skip, repo-relative normalization), significant-action accumulation, `save_to_brag_sheet` flow, category validation, summary sanitization, repo/branch auto-detection, `review_brag_sheet` rendering, `generate_work_log` write, **`brag` keyword regex** (must match standalone, exclude `bragging`/`braggart`), PR info extraction, shell-command git-action detection. | Hooks firing inside the SDK runtime (see "What is NOT covered" below). |
+| [`bin/setup.mjs`](../bin/setup.mjs) | — | 0 | — | Interactive prompts. Non-TTY exit (covered indirectly by CI matrix). |
+| [`bin/install.mjs`](../bin/install.mjs) | install-smoke (CI) | 0 unit | Tarball → `~/.copilot/extensions/...` layout. Re-run idempotency. | Failure path when `COPILOT_HOME` exists but isn't writable. |
+| [`install.sh`](../install.sh) / [`install.ps1`](../install.ps1) | install-smoke (CI) | — | End-to-end install on Linux/macOS, Windows PS 5.1, Windows pwsh 7+ (matches real-world Windows 10/11 default shell). | Air-gapped installs. Behind-corporate-proxy installs. |
+
+**Total: 107 unit tests + 4 install-smoke jobs (3 OS × shells).**
+
+---
+
+## Why some things are intentionally NOT unit-tested
+
+### `extension.mjs` hooks
+
+The entry point starts with:
+
+```js
+import { joinSession } from "@github/copilot-sdk/extension";
+// ...
+const session = await joinSession({ hooks: {...}, tools: [...] });
+```
+
+That import only resolves inside a real Copilot CLI host process — the
+SDK is injected at load time, not installed via npm (it's a peer dep
+declared `optional`). Any test that does
+`import "../extension.mjs"` will throw `ERR_MODULE_NOT_FOUND` outside
+the host.
+
+We work around that by extracting every pure helper from `extension.mjs`
+and re-implementing it (or testing the underlying `lib/*` it delegates
+to). That's why `test/extension.test.mjs` lives next to the entry point
+but doesn't actually import it.
+
+The trade-off: **the wiring between hooks and lib functions is currently
+verified only by manual smoke tests.** That's the largest gap in our
+coverage.
+
+### `bin/setup.mjs`
+
+Interactive `readline` prompts are hard to test cleanly in `node:test`
+without dragging in an interactive-CLI testing library (which would
+violate zero deps). The non-TTY path *is* exercised every time CI
+install-smoke runs without a real terminal — if it ever regresses, that
+job fails, which is exactly what happened before v1.0.3 (`CHANGELOG.md`
+entry "bin/setup.mjs non-TTY hang").
+
+### Real `git` execution
+
+`test/git-backup.test.mjs` injects a fake runner via the `createGitRunner`
+hook pattern (`lib/git-backup.mjs:34-46`). Running real `git` in tests
+would:
+
+- couple us to whatever git version the runner has installed,
+- require a writable HOME with valid `user.email` / `user.name`,
+- introduce flake from clock skew on commit messages.
+
+The mocked path verifies our argv composition, exit-code handling, and
+error logging — which is what we own. The actual git binary is
+upstream's responsibility.
+
+---
+
+## Roadmap to better coverage
+
+These are tracked informally; promote to `ROADMAP.md` if you start work.
+
+### 1. Mock-host hooks tests (high value, medium effort)
+
+**Goal:** verify that `onSessionStart` writes a session record,
+`onPostToolUse` for an `edit` tool appends to `filesEdited`, etc., end-to-end.
+
+**Approach:** ship a tiny `test/_mock-host.mjs` that exposes a fake
+`joinSession` shim, then point a test-only build of `extension.mjs` at
+it via an environment-gated import. Sketch:
+
+```js
+// test/_mock-host.mjs
+export async function joinSession({ hooks, tools }) {
+  return {
+    log: async () => {},
+    on: () => {},
+    __hooks: hooks,
+    __tools: tools,
+  };
+}
+
+// test/extension-hooks.test.mjs
+process.env.WORK_TRACKER_DIR = mkdtempSync(...);
+process.env.BRAG_SHEET_TEST_HOST = "1";
+const ext = await import("../extension.mjs"); // import-mapped to mock
+await ext.__hooks.onSessionStart({ cwd: "/tmp" }, { sessionId: "t1" });
+const records = readRecords(process.env.WORK_TRACKER_DIR);
+assert.equal(records.length, 1);
+```
+
+The import-map can use `node --conditions=test` + a `package.json`
+exports map, or a tiny build step that rewrites the SDK import. The
+github/copilot-sdk team uses essentially this pattern in
+`nodejs/test/extension.test.ts` — that is the exemplar to study.
+
+### 2. Subprocess nightly E2E (high value, high effort)
+
+**Goal:** spawn `node extension.mjs` as a child process, drive it
+through the JSON-RPC stdio protocol, assert it produces the right
+records on disk and the right responses on stdout.
+
+**Why nightly, not per-PR:** cold-start time dominates and these tests
+need a published `@github/copilot-sdk` to actually load. They are also
+the most likely to flake on CI runners with slow disk I/O.
+
+**Trigger:** add `.github/workflows/e2e-nightly.yml` running on a cron,
+not on PRs. Failures open an issue rather than blocking merge.
+
+### 3. Cross-platform path edge cases (medium value, low effort)
+
+- Case-insensitive dedup on Windows/macOS HFS+ (`C:\Foo\bar.js` ===
+  `c:\foo\BAR.js`).
+- UNC paths on Windows (`\\server\share\file.js`).
+- Symlinked repos (resolve real path before storing).
+
+### 4. Property-based tests for sanitize()
+
+`sanitize` is the only place LLM output meets disk. Use a small in-house
+fuzzer (no dependency) that throws random strings at it and asserts:
+
+- output never contains `WEEKLY_ENTRIES_START` / `WEEKLY_ENTRIES_END`,
+- output ≤ 500 chars,
+- output has no unescaped pipes,
+- round-tripping through `sanitize` is a fixpoint.
+
+### 5. Schema migration test scaffold
+
+When (not if) we add a record field, we need to assert that records
+written by an older version still parse. A `test/fixtures/legacy/` dir
+of hand-crafted v1.0.x records, fed through `readRecords`, would catch
+schema drift before users do.
+
+---
+
+## Test-writing conventions
+
+- **Mirror filenames.** `lib/foo.mjs` → `test/foo.test.mjs`.
+- **Use `node:test`.** `describe` / `it` / `before` / `after` only.
+  No `t.test` (callback) style — it's harder to read.
+- **Use `mkdtempSync(join(tmpdir(), "..."))`** for any test that
+  touches disk. Clean up in `after()` with
+  `rmSync(dir, { recursive: true, force: true })`.
+- **No `process.chdir`** — it's not safe in parallel runners.
+- **Make external commands injectable.** Follow `createGitRunner` in
+  `lib/git-backup.mjs` — take an optional function param so the test
+  can pass a stub.
+- **Assertions:** prefer `assert.deepEqual` / `assert.equal` over field-by-
+  field. Match the codex AGENTS.md guidance — "compare entire objects."
+- **One scenario per `it()`.** A test that checks five things should
+  probably be five tests.
+- **Keep tests fast.** Total suite runs in ~750ms today. If a single
+  test takes >100ms, ask why.
+
+---
+
+## Pre-flight checklist for any PR that changes test behavior
+
+- [ ] `npm test` passes locally.
+- [ ] New tests follow the mirror-filename convention.
+- [ ] Disk-touching tests use `mkdtemp` + `after` cleanup.
+- [ ] No new dependencies (devDependencies included).
+- [ ] If the suite count changed, the headline number in
+      [`AGENTS.md` §5](../AGENTS.md#5-testing-strategy) and this
+      doc's "Current state" section have been updated.
+- [ ] If a new `lib/` module was added, it has a matching
+      `test/<name>.test.mjs` with at least three tests covering
+      happy-path, error path, and an edge case.
+
+---
+
+## Related reading
+
+- [`AGENTS.md`](../AGENTS.md) — top-level agent guide. §5 (testing) and
+  §10 (things to never do) are most relevant here.
+- [`CONTRIBUTING.md`](../CONTRIBUTING.md) — human contributor guide;
+  overlaps with the conventions section.
+- [`.github/workflows/ci.yml`](../.github/workflows/ci.yml) — the
+  authoritative source for what CI runs.
+- github/copilot-sdk's `nodejs/test/extension.test.ts` — exemplar for
+  the mock-host approach (#1 above).


### PR DESCRIPTION
Adds top-level `AGENTS.md` (per the [agents.md](https://agents.md/) convention — open Markdown spec, 60k+ repos) plus two supporting docs so any future AI coding agent (Claude Code, Copilot CLI, Codex, Cursor, Jules, Amp) has the context it needs to be productive on this repo **without re-deriving it from grep**.

## What's added

| File | Size | Purpose |
|---|---|---|
| `AGENTS.md` | 28.9 KB / 526 lines | Single entry point. 12 sections per the agents.md convention. |
| `docs/testing-strategy.md` | 12.1 KB / 232 lines | What's covered (107 tests across 8 files), what's intentionally not, roadmap. |
| `docs/security-model.md` | 17.8 KB / 365 lines | STRIDE-lite threat model, data flow, what we do / don't defend against, redaction roadmap. |

## `AGENTS.md` structure

1. Project overview & invariants (zero deps, ESM-only, atomic writes, no PII egress)
2. Architecture map — file table with line citations into `extension.mjs` and `lib/*.mjs`
3. Build / test commands (with PowerShell + bash variants)
4. Code conventions (zero deps, atomic writes, ESM, sanitize-on-write)
5. Testing strategy summary → links to `docs/testing-strategy.md`
6. Security posture summary → links to `docs/security-model.md` and `SECURITY.md`
7. Release process (tag → workflow validates → npm publish --provenance)
8. Distribution channels (npm, awesome-copilot, GH Pages)
9. Repo navigation
10. **Things to NEVER do** — 12 items with file:line citations (e.g. don't add deps, don't bypass `writeRecord`, don't push without all three git flags)
11. Where to find more
12. Quick task playbook — 5 recipes (fix bug / add feature / ship release / add lib module / investigate install)

## Grounded in real code, not general advice

Every claim cites real lines. Examples:
- Atomic write pattern: `lib/storage.mjs:216-244`
- File locking with stale-PID detection: `lib/lock.mjs:94-130`
- Sanitization (markdown injection defense): `lib/records.mjs:50-71`
- Orphan recovery (5-min stale window): `extension.mjs:94-116`
- Emergency synchronous shutdown save: `extension.mjs:558-571`
- 3-flag git push gate: `lib/git-backup.mjs:151-164`

## Exemplars consulted

- [openai/codex AGENTS.md](https://github.com/openai/codex/blob/main/AGENTS.md) — borrowed structural patterns (compare entire objects in tests). Their content is Rust/Bazel-specific and didn't transfer.
- [vercel/next.js AGENTS.md](https://github.com/vercel/next.js/blob/canary/AGENTS.md) — borrowed "Build Commands" + "When NOT to use X" framing. Their content is pnpm-monorepo-specific.
- cline/cline does not have an AGENTS.md (404).

Both exemplars assume a build system + package manager we deliberately avoid (zero-deps constraint), so we kept structural patterns and wrote our own concrete content.

## Verification

- `npm test` → **107 / 0** (unchanged baseline; pure docs change)
- No code modified — no changes under `lib/`, `bin/`, `extension.mjs`, or `test/`
- No version bump
- All file paths and line numbers cited in the docs verified against `main`