### PR TITLE
fix(git-backup): abort unfinished rebase on pull --rebase failure

### DIFF
--- a/lib/git-backup.mjs
+++ b/lib/git-backup.mjs
@@ -151,8 +151,23 @@ export async function backupToGit({ dataDir, gitConfig, runGit }) {
     if (gitConfig.push === true) {
       const remoteExists = await hasRemote(dataDir, git);
       if (remoteExists) {
-        // Pull --rebase to absorb remote changes, then push
-        await git(["pull", "--rebase", "--quiet"], dataDir);
+        // Pull --rebase to absorb remote changes. If the rebase fails (cross-
+        // machine conflict, network blip, etc.) we MUST abort it — leaving an
+        // unfinished rebase makes every subsequent save fail silently because
+        // git refuses new commits while a rebase is in progress.
+        const pullResult = await git(["pull", "--rebase", "--quiet"], dataDir);
+        if (pullResult.code !== 0) {
+          logError(
+            dataDir,
+            "git-backup:pull",
+            pullResult.stderr ||
+              `pull --rebase exited ${pullResult.code} — aborting rebase to keep repo usable`,
+          );
+          // Best-effort cleanup. If we're not in a rebase state, this no-ops.
+          await git(["rebase", "--abort"], dataDir);
+          // Don't push — we'd just propagate desynced local state to remote.
+          return { success: false, action: "pull-conflict" };
+        }
         git(["push", "--quiet"], dataDir).then((pushResult) => {
           if (pushResult.code !== 0) {
             logError(dataDir, "git-backup:push", pushResult.stderr || `exit ${pushResult.code}`);

--- a/test/git-backup.test.mjs
+++ b/test/git-backup.test.mjs
@@ -173,6 +173,37 @@ describe("backupToGit", () => {
     assert.ok(cmds.includes("push"));
   });
 
+  it("aborts rebase and skips push when pull --rebase fails", async () => {
+    // Regression test: previously an unhandled `git pull --rebase` failure
+    // would leave the data-dir repo in an unfinished-rebase state, breaking
+    // every subsequent save (commit refuses while a rebase is in progress).
+    const dataDir = makeDataDir("rebase-conflict");
+    mkdirSync(join(dataDir, ".git"));
+
+    const { runner, calls } = mockGitRunner({
+      diff: { code: 1 },
+      remote: { code: 0, stdout: "https://github.com/u/r.git" },
+      pull: { code: 1, stderr: "CONFLICT: cannot fast-forward" },
+    });
+
+    const result = await backupToGit({
+      dataDir,
+      gitConfig: { enabled: true, push: true },
+      runGit: runner,
+    });
+
+    assert.equal(result.success, false);
+    assert.equal(result.action, "pull-conflict");
+
+    const argsPerCall = calls.map((c) => c.args);
+    // We saw a `pull --rebase`...
+    assert.ok(argsPerCall.some((a) => a[0] === "pull" && a.includes("--rebase")));
+    // ...followed by a cleanup `rebase --abort`...
+    assert.ok(argsPerCall.some((a) => a[0] === "rebase" && a.includes("--abort")));
+    // ...and we did NOT push (would propagate desynced state to remote).
+    assert.ok(!argsPerCall.some((a) => a[0] === "push"));
+  });
+
   it("never throws on unexpected errors", async () => {
     const dataDir = makeDataDir("throws");
     mkdirSync(join(dataDir, ".git"));


### PR DESCRIPTION
Adversarial review of v1.0.4 plan caught the only guardrail-class bug actually likely to bite real users.

## Bug
`backupToGit` runs `git pull --rebase` before pushing. If the rebase failed, the previous code didn't error-check it. Repo was left in unfinished-rebase state. Every subsequent save then silently failed because git refuses commits while a rebase is in progress.

## Fix
- Capture pull --rebase exit code
- On failure, log + `git rebase --abort` to clean up
- Skip the push (propagating desynced state would multiply the problem)
- New `pull-conflict` action so callers can distinguish from generic failures

User-facing impact: local saves keep working; only remote sync pauses until conflict resolved. Next save retries cleanly.

## Tests
+1 regression test. 107 → 108, all green.