### PR TITLE
ci: install runtime deps before running test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
+      - run: npm install --no-audit --no-fund
       - run: npm test
 
   # End-to-end install smoke test — exercises install.sh / install.ps1 on


### PR DESCRIPTION
Standalone CI fix lifted from #33 so it can land independently.

The `test` job in `.github/workflows/ci.yml` did not run `npm install` before `npm test`. That worked while the package had zero runtime dependencies. As soon as we add a runtime dependency (planned in PR #33's MCP-SDK rewrite), the `test` jobs fail at module resolution.

Adds `npm install --no-audit --no-fund` immediately before `npm test` in the test matrix.

The `install-smoke-*` jobs already install deps as part of exercising the install scripts, so they're unaffected.

This PR is no-op today (we still have zero runtime deps) and can land cleanly. Once it merges to `main`, PR #33 rebases on top and CI runs without needing maintainer approval for a workflow-file change from a PR branch.