### PR TITLE
v1.1.0: MCP server bin for non-Copilot hosts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+## [1.1.0] — 2026-05-11
+
+### Added
+
+- **`copilot-brag-sheet-mcp` bin** — `mcp-server.mjs` is now a Model Context Protocol server exposing `save_to_brag_sheet`, `review_brag_sheet`, and `generate_work_log` over stdio. Any MCP host (Claude Desktop, Claude Code, custom hosts) can drive the brag sheet without Copilot CLI installed.
+- **`response_format` parameter on every MCP tool** — `"markdown"` (default) returns the same text the Copilot CLI extension produces; `"json"` returns the underlying record for programmatic callers.
+
+### Changed
+
+- **`generate_work_log` requires an absolute `outputPath`.** Relative paths are rejected at the schema layer so the tool can't silently write into the MCP host's working directory. The Copilot CLI extension already passes absolute paths, so this only affects direct MCP callers.
+- **New runtime dependencies:** `@modelcontextprotocol/sdk` and `zod`. Both are loaded only by `mcp-server.mjs`; `lib/` and `extension.mjs` stay dependency-free.
+
 ## [1.0.3] — 2026-05-01
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "copilot-brag-sheet",
-  "version": "1.0.3",
+  "version": "1.1.0",
   "description": "Auto-track AI coding sessions into a structured work log. Local-first, MCP-conformant.",
   "mcpName": "io.github.microsoft/copilot-brag-sheet",
   "type": "module",


### PR DESCRIPTION
Ships a standalone `copilot-brag-sheet-mcp` bin so the three brag-sheet tools — `save_to_brag_sheet`, `review_brag_sheet`, `generate_work_log` — work in any MCP host: Claude Desktop, Claude Code, custom clients. Each tool gains a `response_format` parameter (`"markdown"` default, `"json"` for programmatic callers). `generate_work_log` now requires an absolute `outputPath` (relative paths are rejected at the schema layer).

The Copilot CLI extension (`extension.mjs`) is untouched — existing users get this as a no-op upgrade.

`package.json` picks up two runtime deps (`@modelcontextprotocol/sdk`, `zod`), consumed only by the MCP server. `lib/` and `extension.mjs` stay dependency-free.

Substance landed in #33. This PR is the version bump and CHANGELOG entry; tagging v1.1.0 triggers `release.yml`.