### PR TITLE
refactor: extract lib/heuristics.mjs + lib/operations.mjs (Phase 0)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,7 +67,9 @@ jobs:
             bin/mcp-server.mjs
             lib/config.mjs
             lib/git-backup.mjs
+            lib/heuristics.mjs
             lib/lock.mjs
+            lib/operations.mjs
             lib/paths.mjs
             lib/records.mjs
             lib/render.mjs

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -109,7 +109,7 @@ This repo has **no build step** (ESM runs directly on Node 18+) and **no
 linter configured** today. The full toolbox is `node --test`.
 
 ```bash
-# Run all 176 tests (ubuntu/macos/windows × Node 18/20/22 in CI)
+# Run all 177 tests (ubuntu/macos/windows × Node 18/20/22 in CI)
 npm test
 
 # Run a single test file
@@ -202,24 +202,24 @@ real bug reports). Don't change them without an issue and discussion first.
 
 ## 5. Testing strategy
 
-Current state: **176 tests, all green, run cross-platform in CI.** Counts
+Current state: **177 tests, all green, run cross-platform in CI.** Counts
 per file (verify with `Select-String -Pattern '^\s*it\('`):
 
 | File | Tests | Covers |
 |---|---:|---|
-| `test/heuristics.test.mjs` | 33 | Tool classification sets, extractFilePath, extractPrInfo, detectShellGitAction, isBragRequest, classifyToolUse. |
-| `test/extension.test.mjs` | 25 | Session record lifecycle, file tracking, significant actions, manual entry creation, review/generate flow, brag/PR/git smoke tests (now importing from lib/heuristics.mjs). |
-| `test/mcp-server.test.mjs` | 20 | MCP server tool handlers via buildServer(), Zod validation, pagination, structured output. |
-| `test/git-backup.test.mjs` | 18 | `ensureGitRepo`, `addRemote`, `backupToGit` with a mocked `git` runner. |
+| `test/heuristics.test.mjs` | 34 | Tool classification sets, extractFilePath, extractPrInfo, detectShellGitAction, isBragRequest (incl. mixed-prompt regression), classifyToolUse. |
+| `test/extension.test.mjs` | 32 | Session record lifecycle, file tracking, significant actions, manual entry creation, review/generate flow, brag/PR/git smoke tests (importing from lib/heuristics.mjs). |
+| `test/git-backup.test.mjs` | 19 | `ensureGitRepo`, `addRemote`, `backupToGit` with a mocked `git` runner. |
+| `test/mcp-server.test.mjs` | 18 | MCP server tool handlers via buildServer(), Zod validation, pagination, structured output. |
 | `test/operations.test.mjs` | 16 | Shared saveBragEntry, reviewBragEntries, generateWorkLog with real disk I/O. |
 | `test/render.test.mjs` | 14 | Markdown rendering, week boundaries (UTC), category grouping, escaping. |
-| `test/storage.test.mjs` | 14 | Atomic JSON/text writes, shard layout, filter semantics, update flow. |
-| `test/pack-smoke.test.mjs` | 10 | Tarball validation, install simulation. |
+| `test/storage.test.mjs` | 12 | Atomic JSON/text writes, shard layout, filter semantics, update flow. |
 | `test/config.test.mjs` | 9 | Default merge, microsoft preset, category resolution. |
 | `test/records.test.mjs` | 8 | Record factories, sanitization, file-path dedup. |
 | `test/paths.test.mjs` | 7 | Per-platform data dir resolution, env-var overrides. |
 | `test/lock.test.mjs` | 7 | Lock acquisition, stale-PID cleanup, contention. |
-| **Total** | **176** | |
+| `test/pack-smoke.test.mjs` | 1 | Tarball validation, install simulation. |
+| **Total** | **177** | |
 
 **What's covered:**
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,8 +77,10 @@ Copilot CLI host  ──spawns──▶  extension.mjs (joinSession)
 |---|---|---|
 | [`paths.mjs`](lib/paths.mjs) | OS-native data dir + path helpers; respects `WORK_TRACKER_DIR` / `XDG_DATA_HOME` / `LOCALAPPDATA`. | `detectDataDir`, `detectBragSheetPath`, `detectGitConfig`, `ensureDir` |
 | [`config.mjs`](lib/config.mjs) | Loads `config.json`, merges with defaults, surfaces `microsoft` preset context. | `loadConfig`, `getAllCategoryIds`, `isValidCategory`, `buildUserContext`, `DEFAULT_CONFIG` |
+| [`heuristics.mjs`](lib/heuristics.mjs) | Tool classification sets, PR/file/git extraction helpers, brag keyword detection, composite `classifyToolUse`. | `FILE_CREATE_TOOLS`, `FILE_EDIT_TOOLS`, `PR_TOOLS`, `SHELL_TOOLS`, `extractFilePath`, `extractPrInfo`, `detectShellGitAction`, `isBragRequest`, `classifyToolUse` |
+| [`operations.mjs`](lib/operations.mjs) | Shared validate→create→persist→backup orchestration for all three tools. Returns `{ ok: true/false }` discriminated results. | `saveBragEntry`, `reviewBragEntries`, `generateWorkLog` |
 | [`lock.mjs`](lib/lock.mjs) | Cross-platform PID-aware file lock (`O_EXCL` create + stale-process detection). | `withFileLock` |
-| [`storage.mjs`](lib/storage.mjs) | Atomic JSON writes (tmp → fsync → rename), shard-aware reads, `updateRecord` under lock. | `atomicWriteJSON`, `writeRecord`, `readRecords`, `updateRecord`, `logError` |
+| [`storage.mjs`](lib/storage.mjs) | Atomic JSON/text writes (tmp → fsync → rename), shard-aware reads, `updateRecord` under lock. | `atomicWriteJSON`, `atomicWriteText`, `writeRecord`, `readRecords`, `updateRecord`, `logError` |
 | [`records.mjs`](lib/records.mjs) | Record factories, sanitization, dedupe, file-path normalization. | `createSessionRecord`, `createEntryRecord`, `addFileToRecord`, `sanitize`, `dedupeArray` |
 | [`render.mjs`](lib/render.mjs) | JSON records → grouped Markdown (`work-log.md`, review summaries). | `weekOf`, `renderMarkdown`, `renderReviewSummary` |
 | [`git-backup.mjs`](lib/git-backup.mjs) | Optional git init / commit / push of the data dir; sessions excluded via auto-generated `.gitignore`. | `ensureGitRepo`, `addRemote`, `hasRemote`, `backupToGit`, `createGitRunner` |
@@ -107,7 +109,7 @@ This repo has **no build step** (ESM runs directly on Node 18+) and **no
 linter configured** today. The full toolbox is `node --test`.
 
 ```bash
-# Run all 107 tests (ubuntu/macos/windows × Node 18/20/22 in CI)
+# Run all 176 tests (ubuntu/macos/windows × Node 18/20/22 in CI)
 npm test
 
 # Run a single test file
@@ -162,8 +164,8 @@ real bug reports). Don't change them without an issue and discussion first.
 - **Atomic JSON writes.** All disk writes go through
   [`atomicWriteJSON`](lib/storage.mjs) (`open` → `writeFile` → `fsyncSync` →
   `closeSync` → `renameSync`, with `unlinkSync` cleanup on failure).
-  See `lib/storage.mjs:216-244`. The same pattern is duplicated for text in
-  `extension.mjs:118-135` (`atomicWriteText`) — keep them in sync.
+  Text writes use `atomicWriteText` in the same module. Both live in
+  `lib/storage.mjs`.
 - **File locking for concurrent writers.** Multi-process safety uses
   [`withFileLock`](lib/lock.mjs) — `O_EXCL` create + PID written into the
   lockfile + 30s stale detection via `process.kill(pid, 0)`. Use it any
@@ -200,20 +202,24 @@ real bug reports). Don't change them without an issue and discussion first.
 
 ## 5. Testing strategy
 
-Current state: **107 tests, all green, run cross-platform in CI.** Counts
+Current state: **176 tests, all green, run cross-platform in CI.** Counts
 per file (verify with `Select-String -Pattern '^\s*it\('`):
 
 | File | Tests | Covers |
 |---|---:|---|
-| `test/extension.test.mjs` | 34 | Pure helpers extracted from `extension.mjs` (record lifecycle, file tracking, brag detection, PR extraction). Hooks themselves are not unit-tested — see below. |
+| `test/heuristics.test.mjs` | 33 | Tool classification sets, extractFilePath, extractPrInfo, detectShellGitAction, isBragRequest, classifyToolUse. |
+| `test/extension.test.mjs` | 25 | Session record lifecycle, file tracking, significant actions, manual entry creation, review/generate flow, brag/PR/git smoke tests (now importing from lib/heuristics.mjs). |
+| `test/mcp-server.test.mjs` | 20 | MCP server tool handlers via buildServer(), Zod validation, pagination, structured output. |
 | `test/git-backup.test.mjs` | 18 | `ensureGitRepo`, `addRemote`, `backupToGit` with a mocked `git` runner. |
+| `test/operations.test.mjs` | 16 | Shared saveBragEntry, reviewBragEntries, generateWorkLog with real disk I/O. |
 | `test/render.test.mjs` | 14 | Markdown rendering, week boundaries (UTC), category grouping, escaping. |
-| `test/storage.test.mjs` | 10 | Atomic writes, shard layout, filter semantics, update flow. |
+| `test/storage.test.mjs` | 14 | Atomic JSON/text writes, shard layout, filter semantics, update flow. |
+| `test/pack-smoke.test.mjs` | 10 | Tarball validation, install simulation. |
 | `test/config.test.mjs` | 9 | Default merge, microsoft preset, category resolution. |
 | `test/records.test.mjs` | 8 | Record factories, sanitization, file-path dedup. |
 | `test/paths.test.mjs` | 7 | Per-platform data dir resolution, env-var overrides. |
 | `test/lock.test.mjs` | 7 | Lock acquisition, stale-PID cleanup, contention. |
-| **Total** | **107** | |
+| **Total** | **176** | |
 
 **What's covered:**
 
@@ -355,11 +361,13 @@ proving distribution conversion before fanning out further.
 
 | Path | Purpose | Modify when... |
 |---|---|---|
-| `extension.mjs` | Copilot CLI entry point: hooks + tools. **Only file that imports the SDK.** | Adding a hook or tool. Wiring new lib functionality into the host. |
+| `extension.mjs` | Copilot CLI entry point: hooks + tools. **Only file that imports the SDK.** Delegates to `lib/*` for all logic. | Adding a hook or tool. Wiring new lib functionality into the host. |
 | `lib/paths.mjs` | OS-native data dir; env-var overrides. | Adding a new path target or platform. |
 | `lib/config.mjs` | Default config + presets + category management. | Adding a preset or default category. |
+| `lib/heuristics.mjs` | Tool classification sets, extraction helpers, brag keyword detection, composite `classifyToolUse`. | Adding a new tool type to track, changing brag-trigger behavior. |
+| `lib/operations.mjs` | Shared save/review/generate orchestration with `{ ok }` returns. Used by extension.mjs, mcp-server.mjs, and future Agency hooks. | Changing save/review/generate behavior across all surfaces. |
 | `lib/lock.mjs` | PID-aware file lock. | Don't, unless you have a strong reason. Battle-tested. |
-| `lib/storage.mjs` | Atomic JSON I/O, shard reads, `updateRecord`. | Adding a new record type or query filter. |
+| `lib/storage.mjs` | Atomic JSON/text I/O, shard reads, `updateRecord`. | Adding a new record type or query filter. |
 | `lib/records.mjs` | Record factories, `sanitize`, `addFileToRecord`. | Changing the record schema (and read §10 first). |
 | `lib/render.mjs` | Records → Markdown. Reserved markers live here. | Changing the work-log Markdown layout. |
 | `lib/git-backup.mjs` | Optional git init/commit/push of data dir. | Adding remote types, fixing git edge cases. |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+### Changed
+
+- **Extracted `lib/heuristics.mjs`** — tool classification sets, extraction helpers (`extractPrInfo`, `detectShellGitAction`), brag keyword detection (`isBragRequest`), and composite `classifyToolUse()` are now importable from any entry point. `extension.mjs` imports from this module instead of defining them inline.
+- **Extracted `lib/operations.mjs`** — shared `saveBragEntry`, `reviewBragEntries`, and `generateWorkLog` with `{ ok: true/false }` discriminated returns. Both `extension.mjs` and `mcp-server.mjs` delegate to these instead of duplicating validate→create→persist→backup logic.
+- **Moved `atomicWriteText` to `lib/storage.mjs`** alongside `atomicWriteJSON`. Previously duplicated in both `extension.mjs` and `mcp-server.mjs`.
+- **`isBragRequest` no longer false-triggers on "bragging" / "braggart"** — the `\b` word boundary already prevented matching; the redundant exclude regex that caused false negatives on mixed prompts was removed.
+- **Whitespace-only summaries are now consistently rejected** across both Copilot CLI and MCP surfaces. Previously the MCP surface accepted `"   "` through Zod's `.min(1)`.
+
+### Fixed
+
+- **git config fallback null guard** — `extension.mjs` now applies the same `?? { enabled: false, push: false }` guard as `mcp-server.mjs`, preventing a potential NPE when `config.git` is undefined.
+
 ## [1.1.0] — 2026-05-11
 
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,16 +30,20 @@ npm install
 
 ```
 extension.mjs        ← Copilot CLI entry point (hooks + tools)
+mcp-server.mjs       ← MCP stdio server (cross-engine)
 lib/
   paths.mjs          ← Data directory detection, path helpers
   config.mjs         ← Config loading and category management
+  heuristics.mjs     ← Tool classification, event detection, brag keyword
+  operations.mjs     ← Shared save/review/generate orchestration
   lock.mjs           ← File locking for concurrent access
-  storage.mjs        ← Atomic JSON read/write, record CRUD
+  storage.mjs        ← Atomic JSON/text read/write, record CRUD
   records.mjs        ← Record creation, sanitization, file tracking
   render.mjs         ← Markdown rendering
   git-backup.mjs     ← Git version history and remote sync
 bin/
   setup.mjs          ← Interactive setup wizard
+  mcp-server.mjs     ← MCP server bin entry point
 install.sh           ← macOS/Linux installer
 install.ps1          ← Windows installer
 plugin.json          ← Copilot CLI plugin manifest

--- a/docs/testing-strategy.md
+++ b/docs/testing-strategy.md
@@ -7,7 +7,7 @@
 
 ## Current state — 2026-05
 
-**177 tests, 100% pass rate, 21 suites, ~750ms total runtime.**
+**177 tests, 100% pass rate, 30 suites, run cross-platform in CI.**
 CI matrix: `{ubuntu-latest, macos-latest, windows-latest} × {Node 18, 20, 22}` =
 **9 combinations** running on every PR and `main` push, plus three
 **install-smoke** jobs that exercise the curl-pipe-bash installers

--- a/docs/testing-strategy.md
+++ b/docs/testing-strategy.md
@@ -7,7 +7,7 @@
 
 ## Current state — 2026-05
 
-**107 tests, 100% pass rate, 14 suites, ~750ms total runtime.**
+**177 tests, 100% pass rate, 21 suites, ~750ms total runtime.**
 CI matrix: `{ubuntu-latest, macos-latest, windows-latest} × {Node 18, 20, 22}` =
 **9 combinations** running on every PR and `main` push, plus three
 **install-smoke** jobs that exercise the curl-pipe-bash installers
@@ -16,7 +16,7 @@ CI matrix: `{ubuntu-latest, macos-latest, windows-latest} × {Node 18, 20, 22}` 
 Run the suite locally:
 
 ```bash
-npm test                                      # all 107
+npm test                                      # all 177
 node --test test/storage.test.mjs             # one file
 node --test --test-name-pattern="atomic"      # one pattern
 ```
@@ -41,17 +41,20 @@ No test framework dependency — we use `node:test` and
 |---|---|---:|---|---|
 | [`lib/paths.mjs`](../lib/paths.mjs) | `test/paths.test.mjs` | 7 | Per-platform data dir resolution (Win/macOS/Linux), env-var overrides (`WORK_TRACKER_DIR`, `XDG_DATA_HOME`, `LOCALAPPDATA`, `WORK_TRACKER_OUTPUT_PATH`), `ensureDir` idempotency. | Symlinked HOME directories. UNC paths on Windows (tracked in [ROADMAP P4](../ROADMAP.md)). |
 | [`lib/config.mjs`](../lib/config.mjs) | `test/config.test.mjs` | 9 | Default config shape, deep-merge with user config, microsoft preset toggles, missing-file fallback, malformed-JSON fallback, category lookup helpers, `buildUserContext` for preset. | Malicious config that injects `__proto__` keys. Unknown preset names (currently silently ignored). |
+| [`lib/heuristics.mjs`](../lib/heuristics.mjs) | `test/heuristics.test.mjs` | 34 | Tool classification sets (create/edit/PR/shell), `extractFilePath`, `extractPrInfo` (GitHub + ADO formats, owner/repo combos, failure results), `detectShellGitAction` (commit/push/null), `isBragRequest` (standalone word, excludes bragging/braggart, mixed prompts, null/empty), `classifyToolUse` composite (all tool types, null args, failed PRs, unrecognized tools). | Custom tool names not in the built-in sets. |
+| [`lib/operations.mjs`](../lib/operations.mjs) | `test/operations.test.mjs` | 16 | `saveBragEntry` (valid save, disk persistence, invalid category with error code, empty/whitespace/newline-only summary rejection, null category, tags, sanitization), `reviewBragEntries` (records + markdown, empty, default weeks, filtering), `generateWorkLog` (file write, default path, zero records). | Concurrent saves (idempotency key deferred). Git backup failure logging. |
 | [`lib/lock.mjs`](../lib/lock.mjs) | `test/lock.test.mjs` | 7 | Successful acquire/release, contention (`EEXIST` retries), stale-PID detection (`process.kill(pid, 0)`), lock-file content readback, timeout. | Multi-process contention (we mock PIDs). Filesystem-level locking on network shares (SMB/NFS). |
-| [`lib/storage.mjs`](../lib/storage.mjs) | `test/storage.test.mjs` | 10 | Atomic write (tmp file cleanup on failure), shard layout (`YYYY/MM/<ts>_<id>.json`), shard-bound filtering on `since`/`until`, type/category/repo/tags filters, `updateRecord` merge semantics, `logError` never throws. | Disk-full scenarios. `fsync` failures (we trust the OS). Records with `Date.parse`-invalid timestamps in old data. |
+| [`lib/storage.mjs`](../lib/storage.mjs) | `test/storage.test.mjs` | 12 | Atomic JSON write (tmp file cleanup on failure), atomic text write (round-trip, overwrite), shard layout (`YYYY/MM/<ts>_<id>.json`), shard-bound filtering on `since`/`until`, type/category/repo/tags filters, `updateRecord` merge semantics, `logError` never throws. | Disk-full scenarios. `fsync` failures (we trust the OS). Records with `Date.parse`-invalid timestamps in old data. |
 | [`lib/records.mjs`](../lib/records.mjs) | `test/records.test.mjs` | 8 | `createSessionRecord` + `createEntryRecord` shape, `sanitize()` (newlines, markers, headings, pipes, length cap), `addFileToRecord` dedup + `.copilot/session-state` filtering + repo-relative path normalization. | Case-insensitive dedup on Windows/macOS. Path traversal (`../`) attempts. |
 | [`lib/render.mjs`](../lib/render.mjs) | `test/render.test.mjs` | 14 | `weekOf` UTC consistency including year boundaries, `renderMarkdown` empty/single/multi-week/multi-category cases, session-log opt-in, escaping pipes in tables, ordering newest-first, "Other" bucket for uncategorized, `renderReviewSummary` window filtering. | Internationalized week boundaries (we hardcode UTC). Locale-specific month names. |
-| [`lib/git-backup.mjs`](../lib/git-backup.mjs) | `test/git-backup.test.mjs` | 18 | `ensureGitRepo` init + idempotent reuse, `addRemote`, `hasRemote`, `backupToGit` happy path / no-changes / commit-fail / push-fail, error logging via the injectable runner pattern (`createGitRunner`). | Real `git` binary execution (we mock). Auth failures on push. Detached HEAD states. Repos with submodules. |
-| [`extension.mjs`](../extension.mjs) | `test/extension.test.mjs` | 34 | Pure helpers extracted from the entry point: session lifecycle (active/finalized/orphaned/emergency-saved), file tracking (edit/create classification, dedup, `.copilot/session-state` skip, repo-relative normalization), significant-action accumulation, `save_to_brag_sheet` flow, category validation, summary sanitization, repo/branch auto-detection, `review_brag_sheet` rendering, `generate_work_log` write, **`brag` keyword regex** (must match standalone, exclude `bragging`/`braggart`), PR info extraction, shell-command git-action detection. | Hooks firing inside the SDK runtime (see "What is NOT covered" below). |
+| [`lib/git-backup.mjs`](../lib/git-backup.mjs) | `test/git-backup.test.mjs` | 19 | `ensureGitRepo` init + idempotent reuse, `addRemote`, `hasRemote`, `backupToGit` happy path / no-changes / commit-fail / push-fail, error logging via the injectable runner pattern (`createGitRunner`). | Real `git` binary execution (we mock). Auth failures on push. Detached HEAD states. Repos with submodules. |
+| [`extension.mjs`](../extension.mjs) | `test/extension.test.mjs` | 32 | Session lifecycle (active/finalized/orphaned/emergency-saved), file tracking (edit/create classification, dedup, `.copilot/session-state` skip, repo-relative normalization), significant-action accumulation, `save_to_brag_sheet` flow, category validation, summary sanitization, repo/branch auto-detection, `review_brag_sheet` rendering, `generate_work_log` write, brag/PR/git smoke tests (importing from `lib/heuristics.mjs`). | Hooks firing inside the SDK runtime (see "What is NOT covered" below). |
+| [`mcp-server.mjs`](../mcp-server.mjs) | `test/mcp-server.test.mjs` | 18 | MCP server tool handlers via `buildServer()`, Zod input validation, pagination, structured output, response_format switching. | Real MCP transport. |
 | [`bin/setup.mjs`](../bin/setup.mjs) | — | 0 | — | Interactive prompts. Non-TTY exit (covered indirectly by CI matrix). |
 | [`bin/install.mjs`](../bin/install.mjs) | install-smoke (CI) | 0 unit | Tarball → `~/.copilot/extensions/...` layout. Re-run idempotency. | Failure path when `COPILOT_HOME` exists but isn't writable. |
 | [`install.sh`](../install.sh) / [`install.ps1`](../install.ps1) | install-smoke (CI) | — | End-to-end install on Linux/macOS, Windows PS 5.1, Windows pwsh 7+ (matches real-world Windows 10/11 default shell). | Air-gapped installs. Behind-corporate-proxy installs. |
 
-**Total: 107 unit tests + 4 install-smoke jobs (3 OS × shells).**
+**Total: 177 unit tests + 4 install-smoke jobs (3 OS × shells).**
 
 ---
 

--- a/extension.mjs
+++ b/extension.mjs
@@ -155,7 +155,7 @@ const session = await joinSession({
         config = loadConfig(dataDir);
         // Let env vars override config.json for backward compat
         const envGitConfig = detectGitConfig();
-        gitConfig = envGitConfig.enabled ? envGitConfig : config.git;
+        gitConfig = envGitConfig.enabled ? envGitConfig : (config?.git ?? { enabled: false, push: false });
         firstPromptCaptured = false;
 
         // Initialize git repo in data dir if enabled

--- a/extension.mjs
+++ b/extension.mjs
@@ -21,7 +21,7 @@ import {
 import { detectDataDir, detectBragSheetPath, detectGitConfig, ensureDir } from "./lib/paths.mjs";
 import { loadConfig, getAllCategoryIds, isValidCategory, buildUserContext } from "./lib/config.mjs";
 import {
-  writeRecord, readRecords, updateRecord, logError,
+  writeRecord, readRecords, updateRecord, logError, atomicWriteText,
 } from "./lib/storage.mjs";
 import { backupToGit, ensureGitRepo, addRemote } from "./lib/git-backup.mjs";
 import {
@@ -34,6 +34,9 @@ import {
   extractFilePath, extractPrInfo, detectShellGitAction, isBragRequest,
   classifyToolUse,
 } from "./lib/heuristics.mjs";
+import {
+  saveBragEntry, reviewBragEntries, generateWorkLog,
+} from "./lib/operations.mjs";
 
 // Debug: log to stderr at module load time so we can verify the host actually loaded us.
 // Gated on env var to avoid noise in normal sessions. Set BRAG_SHEET_DEBUG=1 to enable.
@@ -120,24 +123,7 @@ async function recoverOrphans(dir) {
   }
 }
 
-function atomicWriteText(filePath, text) {
-  const tmpPath = `${filePath}.tmp.${process.pid}`;
-  let fd;
-  try {
-    fd = openSync(tmpPath, "w");
-    writeFileSync(fd, text, "utf8");
-    fsyncSync(fd);
-    closeSync(fd);
-    fd = undefined;
-    renameSync(tmpPath, filePath);
-  } catch (err) {
-    if (fd !== undefined) {
-      try { closeSync(fd); } catch { /* noop */ }
-    }
-    try { unlinkSync(tmpPath); } catch { /* noop */ }
-    throw err;
-  }
-}
+// atomicWriteText is now in lib/storage.mjs
 
 /** Lazy-init dataDir, config, and gitConfig if onSessionStart failed. */
 function ensureInitialized() {
@@ -371,39 +357,23 @@ const session = await joinSession({
         try {
           ensureInitialized();
 
-          if (!args.summary?.trim()) {
-            return {
-              textResultForLlm: "Error: summary is required and cannot be empty",
-              resultType: "failure",
-            };
-          }
-
-          if (args.category && !isValidCategory(config, args.category)) {
-            const valid = getAllCategoryIds(config).join(", ");
-            return {
-              textResultForLlm: `Error: invalid category "${args.category}". Valid: ${valid}`,
-              resultType: "failure",
-            };
-          }
-
-          const entry = createEntryRecord({
-            summary: args.summary,
-            category: args.category || null,
-            impact: args.impact || null,
-            tags: args.tags || [],
+          const result = saveBragEntry({
+            ...args,
             repo: args.repo || sessionRecord?.repo || null,
             branch: args.branch || sessionRecord?.branch || null,
             sessionId: sessionRecord?.id || invocation.sessionId || null,
-          });
+          }, { dataDir, config, gitConfig });
 
-          writeRecord(dataDir, entry);
+          if (!result.ok) {
+            return {
+              textResultForLlm: `Error: ${result.message}`,
+              resultType: "failure",
+            };
+          }
 
-          // Fire-and-forget git backup
-          backupToGit({ dataDir, gitConfig }).catch(() => {});
-
-          const label = args.category ? ` [${args.category}]` : "";
-          await session.log(`📊 Saved to brag sheet: ${entry.summary}`);
-          return `✅ Entry saved to brag sheet${label}: "${entry.summary}"`;
+          const label = result.entry.category ? ` [${result.entry.category}]` : "";
+          await session.log(`📊 Saved to brag sheet: ${result.entry.summary}`);
+          return `✅ Entry saved to brag sheet${label}: "${result.entry.summary}"`;
         } catch (err) {
           logError(dataDir, "save_to_brag_sheet", err);
           return {
@@ -434,19 +404,12 @@ const session = await joinSession({
         try {
           ensureInitialized();
 
-          const weeks = args.weeks ?? 4;
-          const records = readRecords(dataDir, {
-            since: new Date(Date.now() - weeks * 7 * 86400000).toISOString(),
-          });
-          const markdown = renderReviewSummary(records, {
-            weeks,
-            config,
-          });
-          const result = markdown || "No entries found for the requested period.";
+          const result = reviewBragEntries(args, { dataDir, config });
+          const markdown = result.markdown || "No entries found for the requested period.";
           const prefix = config?.preset === "microsoft"
             ? "_Formatted for Connect review. Use impact framing: Did X → Result Y → Evidence Z._\n\n"
             : "";
-          return `${prefix}${result}`;
+          return `${prefix}${markdown}`;
         } catch (err) {
           logError(dataDir, "review_brag_sheet", err);
           return {
@@ -476,17 +439,8 @@ const session = await joinSession({
         try {
           ensureInitialized();
 
-          const records = readRecords(dataDir);
-          const markdown = renderMarkdown(records, { config });
-
-          const outputPath = args.outputPath || detectBragSheetPath(dataDir);
-          ensureDir(path.dirname(outputPath));
-          atomicWriteText(outputPath, markdown);
-
-          // Fire-and-forget git backup
-          backupToGit({ dataDir, gitConfig }).catch(() => {});
-
-          return `✅ Work log generated: ${outputPath} (${records.length} records)`;
+          const result = generateWorkLog(args, { dataDir, config, gitConfig });
+          return `✅ Work log generated: ${result.outputPath} (${result.recordCount} records)`;
         } catch (err) {
           logError(dataDir, "generate_work_log", err);
           return {

--- a/extension.mjs
+++ b/extension.mjs
@@ -14,26 +14,21 @@ import { execFileSync } from "node:child_process";
 import path from "node:path";
 import {
   existsSync as fileExists,
-  openSync, closeSync, writeFileSync, readFileSync as readFile, fsyncSync,
-  renameSync, unlinkSync,
+  readFileSync as readFile,
+  unlinkSync,
 } from "node:fs";
 
-import { detectDataDir, detectBragSheetPath, detectGitConfig, ensureDir } from "./lib/paths.mjs";
-import { loadConfig, getAllCategoryIds, isValidCategory, buildUserContext } from "./lib/config.mjs";
+import { detectDataDir, detectGitConfig, ensureDir } from "./lib/paths.mjs";
+import { loadConfig, getAllCategoryIds, buildUserContext } from "./lib/config.mjs";
 import {
-  writeRecord, readRecords, updateRecord, logError, atomicWriteText,
+  writeRecord, readRecords, updateRecord, logError,
 } from "./lib/storage.mjs";
-import { backupToGit, ensureGitRepo, addRemote } from "./lib/git-backup.mjs";
+import { ensureGitRepo, addRemote } from "./lib/git-backup.mjs";
 import {
-  createSessionRecord, createEntryRecord,
+  createSessionRecord,
   addFileToRecord, sanitize, dedupeArray,
 } from "./lib/records.mjs";
-import { renderMarkdown, renderReviewSummary } from "./lib/render.mjs";
-import {
-  FILE_CREATE_TOOLS, FILE_EDIT_TOOLS, PR_TOOLS, SHELL_TOOLS,
-  extractFilePath, extractPrInfo, detectShellGitAction, isBragRequest,
-  classifyToolUse,
-} from "./lib/heuristics.mjs";
+import { isBragRequest, classifyToolUse } from "./lib/heuristics.mjs";
 import {
   saveBragEntry, reviewBragEntries, generateWorkLog,
 } from "./lib/operations.mjs";
@@ -122,8 +117,6 @@ async function recoverOrphans(dir) {
     } catch { /* best effort */ }
   }
 }
-
-// atomicWriteText is now in lib/storage.mjs
 
 /** Lazy-init dataDir, config, and gitConfig if onSessionStart failed. */
 function ensureInitialized() {

--- a/extension.mjs
+++ b/extension.mjs
@@ -29,6 +29,11 @@ import {
   addFileToRecord, sanitize, dedupeArray,
 } from "./lib/records.mjs";
 import { renderMarkdown, renderReviewSummary } from "./lib/render.mjs";
+import {
+  FILE_CREATE_TOOLS, FILE_EDIT_TOOLS, PR_TOOLS, SHELL_TOOLS,
+  extractFilePath, extractPrInfo, detectShellGitAction, isBragRequest,
+  classifyToolUse,
+} from "./lib/heuristics.mjs";
 
 // Debug: log to stderr at module load time so we can verify the host actually loaded us.
 // Gated on env var to avoid noise in normal sessions. Set BRAG_SHEET_DEBUG=1 to enable.
@@ -148,48 +153,7 @@ function ensureInitialized() {
   }
 }
 
-// ── Tool classification ─────────────────────────────────────────────────────
-
-const FILE_CREATE_TOOLS = new Set(["create", "create_file"]);
-const FILE_EDIT_TOOLS = new Set(["edit", "edit_file", "str_replace_editor"]);
-const PR_TOOLS = new Set([
-  "github-create_pull_request",
-  "github-create_pull_request_with_copilot",
-  "ado-corp-repo_create_pull_request",
-]);
-const SHELL_TOOLS = new Set(["powershell", "bash"]);
-
-function extractFilePath(toolArgs) {
-  return toolArgs?.path || null;
-}
-
-function extractPrInfo(toolName, toolArgs, toolResult) {
-  if (toolResult?.resultType === "failure") return null;
-
-  const title = toolArgs?.title || null;
-  const repo = toolArgs?.repo
-    ? (toolArgs.owner ? `${toolArgs.owner}/${toolArgs.repo}` : toolArgs.repo)
-    : null;
-
-  // Try structured result fields first
-  const resultText = typeof toolResult?.textResultForLlm === "string"
-    ? toolResult.textResultForLlm : "";
-  const numMatch = resultText.match(/"number":\s*(\d+)/)
-    || resultText.match(/pullRequestId["\s:]+(\d+)/i);
-  const prId = numMatch ? parseInt(numMatch[1], 10) : null;
-
-  if (title || prId) {
-    return { id: prId, title: title || "(untitled)", repo };
-  }
-  return null;
-}
-
-function detectShellGitAction(command) {
-  if (!command) return null;
-  if (/\bgit\s+commit\b/i.test(command)) return "git commit";
-  if (/\bgit\s+push\b/i.test(command)) return "git push";
-  return null;
-}
+// Tool classification sets and helpers are now in lib/heuristics.mjs
 
 // ── Extension entry point ───────────────────────────────────────────────────
 
@@ -264,8 +228,8 @@ const session = await joinSession({
         // Build user preference context (injected BEFORE tool selection)
         const userCtx = buildUserContext(config);
 
-        // "brag" keyword detection
-        if (/\bbrag\b/i.test(input.prompt)) {
+        // "brag" keyword detection (heuristic from lib/heuristics.mjs)
+        if (isBragRequest(input.prompt)) {
           const bragContext = [
             "The user wants to save work to their brag sheet.",
             "Summarize what was accomplished and call the `save_to_brag_sheet` tool.",
@@ -290,50 +254,34 @@ const session = await joinSession({
       try {
         if (!sessionRecord || !dataDir) return;
 
-        const { toolName, toolArgs, toolResult } = input;
+        const classification = classifyToolUse(input);
         let changed = false;
 
-        // File operations (local creates and edits)
-        if (FILE_CREATE_TOOLS.has(toolName) || FILE_EDIT_TOOLS.has(toolName)) {
-          const filePath = extractFilePath(toolArgs);
-          if (filePath) {
-            addFileToRecord(sessionRecord, toolName, filePath, repoRoot);
-            changed = true;
-          }
+        // File operations — apply to session record with repo-relative paths
+        for (const filePath of classification.filesCreated) {
+          addFileToRecord(sessionRecord, "create", filePath, repoRoot);
+          changed = true;
         }
-
-        // PR creation
-        if (PR_TOOLS.has(toolName)) {
-          const prInfo = extractPrInfo(toolName, toolArgs, toolResult);
-          if (prInfo) {
-            const existing = sessionRecord.prsCreated || [];
-            if (!existing.some(p => p.id === prInfo.id && p.repo === prInfo.repo)) {
-              sessionRecord.prsCreated = [...existing, prInfo];
-            }
-            sessionRecord.significantActions = dedupeArray([
-              ...sessionRecord.significantActions, "pr created",
-            ]);
-            changed = true;
-          }
-        }
-
-        // Remote file push (tracked as "git push")
-        if (toolName === "github-push_files") {
-          sessionRecord.significantActions = dedupeArray([
-            ...sessionRecord.significantActions, "git push",
-          ]);
+        for (const filePath of classification.filesEdited) {
+          addFileToRecord(sessionRecord, "edit", filePath, repoRoot);
           changed = true;
         }
 
-        // Shell-based git operations
-        if (SHELL_TOOLS.has(toolName)) {
-          const action = detectShellGitAction(toolArgs?.command);
-          if (action) {
-            sessionRecord.significantActions = dedupeArray([
-              ...sessionRecord.significantActions, action,
-            ]);
-            changed = true;
+        // PR creation — dedupe by id+repo
+        for (const prInfo of classification.prsCreated) {
+          const existing = sessionRecord.prsCreated || [];
+          if (!existing.some(p => p.id === prInfo.id && p.repo === prInfo.repo)) {
+            sessionRecord.prsCreated = [...existing, prInfo];
           }
+          changed = true;
+        }
+
+        // Significant actions — dedupe
+        for (const action of classification.significantActions) {
+          sessionRecord.significantActions = dedupeArray([
+            ...sessionRecord.significantActions, action,
+          ]);
+          changed = true;
         }
 
         // Incremental save (crash-safe)

--- a/lib/heuristics.mjs
+++ b/lib/heuristics.mjs
@@ -1,0 +1,118 @@
+/**
+ * @fileoverview Tool classification and event detection heuristics.
+ *
+ * Pure functions for classifying Copilot tool calls into semantic events
+ * (file edits, PR creation, git actions) and detecting user intent signals
+ * (brag keyword). Extracted from extension.mjs so any entry point —
+ * Copilot CLI extension, MCP server, Agency hooks — can reuse the same
+ * classification logic without duplication.
+ *
+ * Dependency-free (no SDK, no Zod). Node 18+.
+ *
+ * @license MIT
+ * @see https://github.com/microsoft/copilot-brag-sheet
+ */
+
+// ── Tool classification sets ────────────────────────────────────────────────
+
+export const FILE_CREATE_TOOLS = new Set(["create", "create_file"]);
+export const FILE_EDIT_TOOLS = new Set(["edit", "edit_file", "str_replace_editor"]);
+export const PR_TOOLS = new Set([
+  "github-create_pull_request",
+  "github-create_pull_request_with_copilot",
+  "ado-corp-repo_create_pull_request",
+]);
+export const SHELL_TOOLS = new Set(["powershell", "bash"]);
+
+// ── Extraction helpers ──────────────────────────────────────────────────────
+
+export function extractFilePath(toolArgs) {
+  return toolArgs?.path || null;
+}
+
+export function extractPrInfo(toolName, toolArgs, toolResult) {
+  if (toolResult?.resultType === "failure") return null;
+
+  const title = toolArgs?.title || null;
+  const repo = toolArgs?.repo
+    ? (toolArgs.owner ? `${toolArgs.owner}/${toolArgs.repo}` : toolArgs.repo)
+    : null;
+
+  const resultText = typeof toolResult?.textResultForLlm === "string"
+    ? toolResult.textResultForLlm : "";
+  const numMatch = resultText.match(/"number":\s*(\d+)/)
+    || resultText.match(/pullRequestId["\s:]+(\d+)/i);
+  const prId = numMatch ? parseInt(numMatch[1], 10) : null;
+
+  if (title || prId) {
+    return { id: prId, title: title || "(untitled)", repo };
+  }
+  return null;
+}
+
+export function detectShellGitAction(command) {
+  if (!command) return null;
+  if (/\bgit\s+commit\b/i.test(command)) return "git commit";
+  if (/\bgit\s+push\b/i.test(command)) return "git push";
+  return null;
+}
+
+// ── Brag keyword detection ──────────────────────────────────────────────────
+
+const BRAG_REGEX = /\bbrag\b/i;
+const BRAG_EXCLUDE_REGEX = /brag(?:ging|gart)/i;
+
+export function isBragRequest(prompt) {
+  if (!prompt) return false;
+  return BRAG_REGEX.test(prompt) && !BRAG_EXCLUDE_REGEX.test(prompt);
+}
+
+// ── Composite classifier ────────────────────────────────────────────────────
+
+/**
+ * Classify a single tool call into semantic events.
+ *
+ * Returns a pure data object describing what happened — no mutation,
+ * no side effects. The caller decides how to apply the result to its
+ * own state (session record, hook output, etc.).
+ *
+ * @param {{ toolName: string, toolArgs: object|null, toolResult: object }} input
+ * @returns {{ filesCreated: string[], filesEdited: string[], prsCreated: object[], significantActions: string[] }}
+ */
+export function classifyToolUse({ toolName, toolArgs, toolResult }) {
+  const filesCreated = [];
+  const filesEdited = [];
+  const prsCreated = [];
+  const significantActions = [];
+
+  // File operations
+  if (FILE_CREATE_TOOLS.has(toolName)) {
+    const filePath = extractFilePath(toolArgs);
+    if (filePath) filesCreated.push(filePath);
+  } else if (FILE_EDIT_TOOLS.has(toolName)) {
+    const filePath = extractFilePath(toolArgs);
+    if (filePath) filesEdited.push(filePath);
+  }
+
+  // PR creation
+  if (PR_TOOLS.has(toolName)) {
+    const prInfo = extractPrInfo(toolName, toolArgs, toolResult);
+    if (prInfo) {
+      prsCreated.push(prInfo);
+      significantActions.push("pr created");
+    }
+  }
+
+  // Remote file push
+  if (toolName === "github-push_files") {
+    significantActions.push("git push");
+  }
+
+  // Shell-based git operations
+  if (SHELL_TOOLS.has(toolName)) {
+    const action = detectShellGitAction(toolArgs?.command);
+    if (action) significantActions.push(action);
+  }
+
+  return { filesCreated, filesEdited, prsCreated, significantActions };
+}

--- a/lib/heuristics.mjs
+++ b/lib/heuristics.mjs
@@ -60,11 +60,19 @@ export function detectShellGitAction(command) {
 // ── Brag keyword detection ──────────────────────────────────────────────────
 
 const BRAG_REGEX = /\bbrag\b/i;
-const BRAG_EXCLUDE_REGEX = /brag(?:ging|gart)/i;
 
+/**
+ * Detect whether the user is asking to save work to their brag sheet.
+ *
+ * The `\b` word boundary already prevents matching "bragging" or
+ * "braggart" — no exclusion regex needed.
+ *
+ * @param {string|null|undefined} prompt
+ * @returns {boolean}
+ */
 export function isBragRequest(prompt) {
   if (!prompt) return false;
-  return BRAG_REGEX.test(prompt) && !BRAG_EXCLUDE_REGEX.test(prompt);
+  return BRAG_REGEX.test(prompt);
 }
 
 // ── Composite classifier ────────────────────────────────────────────────────

--- a/lib/operations.mjs
+++ b/lib/operations.mjs
@@ -1,0 +1,128 @@
+/**
+ * @fileoverview Shared tool handler operations.
+ *
+ * Encapsulates the "validate → create → persist → backup" orchestration
+ * used by every entry point (Copilot CLI extension, MCP server, Agency
+ * hooks). Each function returns a discriminated result object
+ * `{ ok: true, ... }` or `{ ok: false, code, message, ... }` so callers
+ * can format the response for their surface without re-implementing
+ * the core logic.
+ *
+ * Dependency-free (no SDK, no Zod). Node 18+.
+ *
+ * @license MIT
+ * @see https://github.com/microsoft/copilot-brag-sheet
+ */
+
+import path from "node:path";
+import { statSync } from "node:fs";
+
+import { detectBragSheetPath, ensureDir } from "./paths.mjs";
+import { getAllCategoryIds, isValidCategory } from "./config.mjs";
+import { writeRecord, readRecords, atomicWriteText, logError } from "./storage.mjs";
+import { backupToGit } from "./git-backup.mjs";
+import { createEntryRecord } from "./records.mjs";
+import { renderMarkdown, renderReviewSummary } from "./render.mjs";
+
+// ── saveBragEntry ───────────────────────────────────────────────────────────
+
+/**
+ * Validate, create, persist, and optionally git-backup a brag entry.
+ *
+ * @param {{ summary: string, category?: string, impact?: string, tags?: string[], repo?: string, branch?: string, sessionId?: string }} args
+ * @param {{ dataDir: string, config: object, gitConfig: object }} ctx
+ * @returns {{ ok: true, entry: object, filePath: string } | { ok: false, code: string, message: string, validCategories?: string[] }}
+ */
+export function saveBragEntry(args, { dataDir, config, gitConfig }) {
+  // Validate summary
+  if (!args.summary?.trim()) {
+    return {
+      ok: false,
+      code: "empty_summary",
+      message: "summary is required and cannot be empty",
+    };
+  }
+
+  // Validate category
+  if (args.category && !isValidCategory(config, args.category)) {
+    const validCategories = getAllCategoryIds(config);
+    return {
+      ok: false,
+      code: "invalid_category",
+      message: `invalid category "${args.category}". Valid: ${validCategories.join(", ")}`,
+      validCategories,
+    };
+  }
+
+  const entry = createEntryRecord({
+    summary: args.summary,
+    category: args.category || null,
+    impact: args.impact || null,
+    tags: Array.isArray(args.tags) ? args.tags : [],
+    repo: args.repo || null,
+    branch: args.branch || null,
+    sessionId: args.sessionId || null,
+  });
+
+  const filePath = writeRecord(dataDir, entry);
+
+  // Fire-and-forget git backup — never block on network I/O
+  backupToGit({ dataDir, gitConfig }).catch((err) =>
+    logError(dataDir, "git-backup", err),
+  );
+
+  return { ok: true, entry, filePath };
+}
+
+// ── reviewBragEntries ───────────────────────────────────────────────────────
+
+/**
+ * Read and render recent brag entries.
+ *
+ * Returns the raw records plus a pre-rendered markdown summary. Callers
+ * handle pagination, truncation, and structured output as needed for
+ * their surface.
+ *
+ * @param {{ weeks?: number }} args
+ * @param {{ dataDir: string, config: object }} ctx
+ * @returns {{ ok: true, records: object[], markdown: string, weeks: number }}
+ */
+export function reviewBragEntries(args, { dataDir, config }) {
+  const weeks = args.weeks ?? 4;
+
+  const records = readRecords(dataDir, {
+    since: new Date(Date.now() - weeks * 7 * 86400000).toISOString(),
+  });
+
+  const markdown = renderReviewSummary(records, { weeks, config });
+
+  return { ok: true, records, markdown: markdown || "", weeks };
+}
+
+// ── generateWorkLog ─────────────────────────────────────────────────────────
+
+/**
+ * Generate the complete work-log markdown file.
+ *
+ * @param {{ outputPath?: string }} args
+ * @param {{ dataDir: string, config: object, gitConfig: object }} ctx
+ * @returns {{ ok: true, outputPath: string, recordCount: number, bytesWritten: number }}
+ */
+export function generateWorkLog(args, { dataDir, config, gitConfig }) {
+  const records = readRecords(dataDir);
+  const markdown = renderMarkdown(records, { config });
+
+  const outputPath = args.outputPath || detectBragSheetPath(dataDir);
+  ensureDir(path.dirname(outputPath));
+  atomicWriteText(outputPath, markdown);
+
+  // Fire-and-forget git backup
+  backupToGit({ dataDir, gitConfig }).catch((err) =>
+    logError(dataDir, "git-backup", err),
+  );
+
+  let bytesWritten = 0;
+  try { bytesWritten = statSync(outputPath).size; } catch { /* noop */ }
+
+  return { ok: true, outputPath, recordCount: records.length, bytesWritten };
+}

--- a/lib/storage.mjs
+++ b/lib/storage.mjs
@@ -311,3 +311,22 @@ export function logError(dataDir, context, error) {
     // Never throw from logging.
   }
 }
+
+export function atomicWriteText(filePath, text) {
+  const tmpPath = `${filePath}.tmp.${process.pid}`;
+  let fd;
+  try {
+    fd = openSync(tmpPath, "w");
+    writeFileSync(fd, text, "utf8");
+    fsyncSync(fd);
+    closeSync(fd);
+    fd = undefined;
+    renameSync(tmpPath, filePath);
+  } catch (error) {
+    if (fd !== undefined) {
+      try { closeSync(fd); } catch { /* noop */ }
+    }
+    try { unlinkSync(tmpPath); } catch { /* noop */ }
+    throw error;
+  }
+}

--- a/mcp-server.mjs
+++ b/mcp-server.mjs
@@ -28,21 +28,19 @@
 
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import {
-  openSync, closeSync, writeFileSync, fsyncSync,
-  renameSync, unlinkSync, readFileSync, statSync,
-} from "node:fs";
+import { readFileSync } from "node:fs";
 
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { z } from "zod";
 
-import { detectDataDir, detectBragSheetPath, detectGitConfig, ensureDir } from "./lib/paths.mjs";
-import { loadConfig, getAllCategoryIds, isValidCategory } from "./lib/config.mjs";
-import { writeRecord, readRecords, logError } from "./lib/storage.mjs";
-import { backupToGit } from "./lib/git-backup.mjs";
-import { createEntryRecord } from "./lib/records.mjs";
-import { renderMarkdown, renderReviewSummary } from "./lib/render.mjs";
+import { detectDataDir, detectGitConfig, ensureDir } from "./lib/paths.mjs";
+import { loadConfig } from "./lib/config.mjs";
+import { logError } from "./lib/storage.mjs";
+import { renderReviewSummary } from "./lib/render.mjs";
+import {
+  saveBragEntry, reviewBragEntries, generateWorkLog,
+} from "./lib/operations.mjs";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -88,24 +86,7 @@ function ensureInitialized() {
   }
 }
 
-function atomicWriteText(filePath, text) {
-  const tmpPath = `${filePath}.tmp.${process.pid}`;
-  let fd;
-  try {
-    fd = openSync(tmpPath, "w");
-    writeFileSync(fd, text, "utf8");
-    fsyncSync(fd);
-    closeSync(fd);
-    fd = undefined;
-    renameSync(tmpPath, filePath);
-  } catch (err) {
-    if (fd !== undefined) {
-      try { closeSync(fd); } catch { /* noop */ }
-    }
-    try { unlinkSync(tmpPath); } catch { /* noop */ }
-    throw err;
-  }
-}
+// atomicWriteText is now in lib/storage.mjs
 
 function truncateMarkdown(markdown) {
   if (typeof markdown !== "string" || markdown.length <= CHARACTER_LIMIT) {
@@ -271,21 +252,7 @@ function renderReviewMarkdown({ records, weeks, total, offset, hasMore }) {
 async function handleSaveToBragSheet(args) {
   ensureInitialized();
 
-  if (args.category && !isValidCategory(config, args.category)) {
-    const valid = getAllCategoryIds(config).join(", ");
-    return toolError(
-      `invalid category "${args.category}". Valid: ${valid}`,
-      {
-        success: false,
-        entryId: "",
-        category: args.category,
-        summary: args.summary,
-        timestamp: new Date().toISOString(),
-      },
-    );
-  }
-
-  const entry = createEntryRecord({
+  const result = saveBragEntry({
     summary: args.summary,
     category: args.category || null,
     impact: args.impact || null,
@@ -293,24 +260,32 @@ async function handleSaveToBragSheet(args) {
     repo: args.repo || null,
     branch: args.branch || null,
     sessionId: null,
-  });
+  }, { dataDir, config, gitConfig });
 
-  writeRecord(dataDir, entry);
-
-  // Fire-and-forget git backup — never block the tool response on network I/O.
-  backupToGit({ dataDir, gitConfig }).catch(() => {});
+  if (!result.ok) {
+    return toolError(
+      result.message,
+      {
+        success: false,
+        entryId: "",
+        category: args.category || null,
+        summary: args.summary,
+        timestamp: new Date().toISOString(),
+      },
+    );
+  }
 
   const structuredContent = {
     success: true,
-    entryId: entry.id,
-    category: entry.category,
-    summary: entry.summary,
-    timestamp: entry.timestamp,
+    entryId: result.entry.id,
+    category: result.entry.category,
+    summary: result.entry.summary,
+    timestamp: result.entry.timestamp,
   };
 
   const text = args.response_format === "json"
     ? JSON.stringify(structuredContent, null, 2)
-    : renderSavedMarkdown(entry);
+    : renderSavedMarkdown(result.entry);
 
   return toolText(text, structuredContent);
 }
@@ -322,11 +297,10 @@ async function handleReviewBragSheet(args) {
   const limit = args.limit ?? DEFAULT_REVIEW_LIMIT;
   const offset = args.offset ?? 0;
 
-  const allRecords = readRecords(dataDir, {
-    since: new Date(Date.now() - weeks * 7 * 86400000).toISOString(),
-  });
+  const result = reviewBragEntries({ weeks }, { dataDir, config });
 
-  // Newest first so paging mirrors how reviewers read the log.
+  // MCP-specific: sort newest-first, apply pagination
+  const allRecords = result.records;
   allRecords.sort((a, b) => (a.timestamp < b.timestamp ? 1 : a.timestamp > b.timestamp ? -1 : 0));
 
   const total = allRecords.length;
@@ -364,29 +338,18 @@ async function handleReviewBragSheet(args) {
 async function handleGenerateWorkLog(args) {
   ensureInitialized();
 
-  const records = readRecords(dataDir);
-  const markdown = renderMarkdown(records, { config });
-
-  const outputPath = args.outputPath || detectBragSheetPath(dataDir);
-  ensureDir(path.dirname(outputPath));
-  atomicWriteText(outputPath, markdown);
-
-  // Fire-and-forget git backup.
-  backupToGit({ dataDir, gitConfig }).catch(() => {});
-
-  let bytesWritten = 0;
-  try { bytesWritten = statSync(outputPath).size; } catch { /* noop */ }
+  const result = generateWorkLog(args, { dataDir, config, gitConfig });
 
   const structuredContent = {
     success: true,
-    outputPath,
-    recordCount: records.length,
-    bytesWritten,
+    outputPath: result.outputPath,
+    recordCount: result.recordCount,
+    bytesWritten: result.bytesWritten,
   };
 
   const text = args.response_format === "json"
     ? JSON.stringify(structuredContent, null, 2)
-    : `✅ Work log generated: ${outputPath} (${records.length} records, ${bytesWritten} bytes)`;
+    : `✅ Work log generated: ${result.outputPath} (${result.recordCount} records, ${result.bytesWritten} bytes)`;
 
   return toolText(text, structuredContent);
 }

--- a/test/extension.test.mjs
+++ b/test/extension.test.mjs
@@ -26,6 +26,9 @@ import {
   addFileToRecord, sanitize, dedupeArray,
 } from "../lib/records.mjs";
 import { renderMarkdown, renderReviewSummary } from "../lib/render.mjs";
+import {
+  isBragRequest, extractPrInfo, detectShellGitAction,
+} from "../lib/heuristics.mjs";
 
 // ── Test fixtures ───────────────────────────────────────────────────────────
 
@@ -315,69 +318,48 @@ describe("extension generate_work_log flow", () => {
 });
 
 // ── Brag keyword detection ──────────────────────────────────────────────────
+// Now tested comprehensively in test/heuristics.test.mjs via real imports.
+// Keep a smoke test here to verify extension-level integration.
 
 describe("extension brag keyword detection", () => {
-  const bragRegex = /\bbrag\b/i;
-  const excludeRegex = /brag(?:ging|gart)/i;
-
-  function shouldTriggerBrag(prompt) {
-    return bragRegex.test(prompt) && !excludeRegex.test(prompt);
-  }
-
   it("detects 'brag' as standalone word", () => {
-    assert.ok(shouldTriggerBrag("Save this to my brag sheet"));
-    assert.ok(shouldTriggerBrag("brag"));
-    assert.ok(shouldTriggerBrag("BRAG about this"));
+    assert.ok(isBragRequest("Save this to my brag sheet"));
+    assert.ok(isBragRequest("brag"));
   });
 
   it("excludes bragging and braggart", () => {
-    assert.ok(!shouldTriggerBrag("stop bragging"));
-    assert.ok(!shouldTriggerBrag("don't be a braggart"));
-  });
-
-  it("does not trigger on unrelated text", () => {
-    assert.ok(!shouldTriggerBrag("fix the login bug"));
-    assert.ok(!shouldTriggerBrag("review my code"));
+    assert.ok(!isBragRequest("stop bragging"));
+    assert.ok(!isBragRequest("don't be a braggart"));
   });
 });
 
 // ── PR info extraction ──────────────────────────────────────────────────────
+// Now tested comprehensively in test/heuristics.test.mjs via real imports.
+// Keep a smoke test here for extension-level integration.
 
 describe("extension PR info extraction", () => {
   it("extracts PR info from tool args", () => {
-    // Simulate the extractPrInfo logic inline (can't import from extension.mjs)
-    const toolArgs = { title: "fix: auth bug", owner: "org", repo: "api" };
-    const toolResult = { resultType: "success", textResultForLlm: '{"number": 42}' };
+    const args = { title: "fix: auth bug", owner: "org", repo: "api" };
+    const result = { resultType: "success", textResultForLlm: '{"number": 42}' };
 
-    const title = toolArgs.title || null;
-    const repo = toolArgs.repo
-      ? (toolArgs.owner ? `${toolArgs.owner}/${toolArgs.repo}` : toolArgs.repo)
-      : null;
-    const numMatch = toolResult.textResultForLlm.match(/"number":\s*(\d+)/);
-    const prId = numMatch ? parseInt(numMatch[1], 10) : null;
-
-    assert.equal(title, "fix: auth bug");
-    assert.equal(repo, "org/api");
-    assert.equal(prId, 42);
+    const info = extractPrInfo("github-create_pull_request", args, result);
+    assert.equal(info.title, "fix: auth bug");
+    assert.equal(info.repo, "org/api");
+    assert.equal(info.id, 42);
   });
 
   it("returns null on failure result", () => {
-    const toolResult = { resultType: "failure", textResultForLlm: "Error" };
-    assert.equal(toolResult.resultType, "failure");
-    // extractPrInfo returns null for failures
+    const args = { title: "fix" };
+    const result = { resultType: "failure", textResultForLlm: "Error" };
+    assert.equal(extractPrInfo("github-create_pull_request", args, result), null);
   });
 });
 
 // ── Git action detection ────────────────────────────────────────────────────
+// Now tested comprehensively in test/heuristics.test.mjs via real imports.
+// Keep a smoke test here for extension-level integration.
 
 describe("extension git action detection from shell commands", () => {
-  function detectShellGitAction(command) {
-    if (!command) return null;
-    if (/\bgit\s+commit\b/i.test(command)) return "git commit";
-    if (/\bgit\s+push\b/i.test(command)) return "git push";
-    return null;
-  }
-
   it("detects git commit", () => {
     assert.equal(detectShellGitAction('git commit -m "fix"'), "git commit");
   });
@@ -388,18 +370,11 @@ describe("extension git action detection from shell commands", () => {
 
   it("returns null for non-git commands", () => {
     assert.equal(detectShellGitAction("npm test"), null);
-    assert.equal(detectShellGitAction("ls -la"), null);
   });
 
   it("returns null for empty/null commands", () => {
     assert.equal(detectShellGitAction(null), null);
     assert.equal(detectShellGitAction(""), null);
-  });
-
-  it("only detects commit and push (not merge/rebase/tag)", () => {
-    assert.equal(detectShellGitAction("git merge main"), null);
-    assert.equal(detectShellGitAction("git rebase -i HEAD~3"), null);
-    assert.equal(detectShellGitAction("git tag v1.0"), null);
   });
 });
 

--- a/test/heuristics.test.mjs
+++ b/test/heuristics.test.mjs
@@ -170,6 +170,11 @@ describe("heuristics isBragRequest", () => {
     assert.ok(!isBragRequest("don't be a braggart"));
   });
 
+  it("detects brag even when bragging also appears in prompt", () => {
+    assert.ok(isBragRequest("bragging rights aside, brag about this fix"));
+    assert.ok(isBragRequest("don't be a braggart — brag about this"));
+  });
+
   it("does not trigger on unrelated text", () => {
     assert.ok(!isBragRequest("fix the login bug"));
     assert.ok(!isBragRequest("review my code"));

--- a/test/heuristics.test.mjs
+++ b/test/heuristics.test.mjs
@@ -1,0 +1,288 @@
+/**
+ * Tests for lib/heuristics.mjs — tool classification and event detection.
+ *
+ * Migrated from inline re-implementations in test/extension.test.mjs to
+ * real imports. These define the contract for the heuristics module.
+ */
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  FILE_CREATE_TOOLS,
+  FILE_EDIT_TOOLS,
+  PR_TOOLS,
+  SHELL_TOOLS,
+  extractFilePath,
+  extractPrInfo,
+  detectShellGitAction,
+  isBragRequest,
+  classifyToolUse,
+} from "../lib/heuristics.mjs";
+
+// ── Tool classification sets ────────────────────────────────────────────────
+
+describe("heuristics tool classification sets", () => {
+  it("FILE_CREATE_TOOLS contains expected tools", () => {
+    assert.ok(FILE_CREATE_TOOLS.has("create"));
+    assert.ok(FILE_CREATE_TOOLS.has("create_file"));
+    assert.ok(!FILE_CREATE_TOOLS.has("edit"));
+  });
+
+  it("FILE_EDIT_TOOLS contains expected tools", () => {
+    assert.ok(FILE_EDIT_TOOLS.has("edit"));
+    assert.ok(FILE_EDIT_TOOLS.has("edit_file"));
+    assert.ok(FILE_EDIT_TOOLS.has("str_replace_editor"));
+    assert.ok(!FILE_EDIT_TOOLS.has("create"));
+  });
+
+  it("PR_TOOLS contains expected tools", () => {
+    assert.ok(PR_TOOLS.has("github-create_pull_request"));
+    assert.ok(PR_TOOLS.has("github-create_pull_request_with_copilot"));
+    assert.ok(PR_TOOLS.has("ado-corp-repo_create_pull_request"));
+    assert.ok(!PR_TOOLS.has("github-list_pull_requests"));
+  });
+
+  it("SHELL_TOOLS contains expected tools", () => {
+    assert.ok(SHELL_TOOLS.has("powershell"));
+    assert.ok(SHELL_TOOLS.has("bash"));
+    assert.ok(!SHELL_TOOLS.has("node"));
+  });
+});
+
+// ── extractFilePath ─────────────────────────────────────────────────────────
+
+describe("heuristics extractFilePath", () => {
+  it("extracts path from tool args", () => {
+    assert.equal(extractFilePath({ path: "/repo/src/main.ts" }), "/repo/src/main.ts");
+  });
+
+  it("returns null when no path property", () => {
+    assert.equal(extractFilePath({ file: "test.js" }), null);
+    assert.equal(extractFilePath({}), null);
+  });
+
+  it("returns null for null/undefined args", () => {
+    assert.equal(extractFilePath(null), null);
+    assert.equal(extractFilePath(undefined), null);
+  });
+});
+
+// ── extractPrInfo ───────────────────────────────────────────────────────────
+
+describe("heuristics extractPrInfo", () => {
+  it("extracts PR info from tool args and result", () => {
+    const args = { title: "fix: auth bug", owner: "org", repo: "api" };
+    const result = { resultType: "success", textResultForLlm: '{"number": 42}' };
+
+    const info = extractPrInfo("github-create_pull_request", args, result);
+    assert.equal(info.title, "fix: auth bug");
+    assert.equal(info.repo, "org/api");
+    assert.equal(info.id, 42);
+  });
+
+  it("returns null on failure result", () => {
+    const args = { title: "fix" };
+    const result = { resultType: "failure", textResultForLlm: "Error" };
+    assert.equal(extractPrInfo("github-create_pull_request", args, result), null);
+  });
+
+  it("extracts PR number from pullRequestId pattern", () => {
+    const args = { title: "feat", owner: "ms", repo: "proj" };
+    const result = { resultType: "success", textResultForLlm: 'pullRequestId: 99' };
+
+    const info = extractPrInfo("ado-corp-repo_create_pull_request", args, result);
+    assert.equal(info.id, 99);
+  });
+
+  it("returns info with title even without PR number", () => {
+    const args = { title: "my pr", owner: "me", repo: "stuff" };
+    const result = { resultType: "success", textResultForLlm: "created" };
+
+    const info = extractPrInfo("github-create_pull_request", args, result);
+    assert.equal(info.title, "my pr");
+    assert.equal(info.id, null);
+  });
+
+  it("builds repo as owner/repo when both present", () => {
+    const args = { title: "x", owner: "org", repo: "r" };
+    const result = { resultType: "success", textResultForLlm: "" };
+
+    const info = extractPrInfo("github-create_pull_request", args, result);
+    assert.equal(info.repo, "org/r");
+  });
+
+  it("uses repo alone when owner is absent", () => {
+    const args = { title: "x", repo: "solo" };
+    const result = { resultType: "success", textResultForLlm: "" };
+
+    const info = extractPrInfo("github-create_pull_request", args, result);
+    assert.equal(info.repo, "solo");
+  });
+
+  it("returns null when no title and no PR number", () => {
+    const args = {};
+    const result = { resultType: "success", textResultForLlm: "done" };
+    assert.equal(extractPrInfo("github-create_pull_request", args, result), null);
+  });
+});
+
+// ── detectShellGitAction ────────────────────────────────────────────────────
+
+describe("heuristics detectShellGitAction", () => {
+  it("detects git commit", () => {
+    assert.equal(detectShellGitAction('git commit -m "fix"'), "git commit");
+  });
+
+  it("detects git push", () => {
+    assert.equal(detectShellGitAction("git push origin main"), "git push");
+  });
+
+  it("returns null for non-git commands", () => {
+    assert.equal(detectShellGitAction("npm test"), null);
+    assert.equal(detectShellGitAction("ls -la"), null);
+  });
+
+  it("returns null for empty/null commands", () => {
+    assert.equal(detectShellGitAction(null), null);
+    assert.equal(detectShellGitAction(""), null);
+    assert.equal(detectShellGitAction(undefined), null);
+  });
+
+  it("only detects commit and push (not merge/rebase/tag)", () => {
+    assert.equal(detectShellGitAction("git merge main"), null);
+    assert.equal(detectShellGitAction("git rebase -i HEAD~3"), null);
+    assert.equal(detectShellGitAction("git tag v1.0"), null);
+  });
+});
+
+// ── isBragRequest ───────────────────────────────────────────────────────────
+
+describe("heuristics isBragRequest", () => {
+  it("detects 'brag' as standalone word", () => {
+    assert.ok(isBragRequest("Save this to my brag sheet"));
+    assert.ok(isBragRequest("brag"));
+    assert.ok(isBragRequest("BRAG about this"));
+  });
+
+  it("excludes bragging and braggart", () => {
+    assert.ok(!isBragRequest("stop bragging"));
+    assert.ok(!isBragRequest("don't be a braggart"));
+  });
+
+  it("does not trigger on unrelated text", () => {
+    assert.ok(!isBragRequest("fix the login bug"));
+    assert.ok(!isBragRequest("review my code"));
+  });
+
+  it("returns false for null/undefined/empty", () => {
+    assert.ok(!isBragRequest(null));
+    assert.ok(!isBragRequest(undefined));
+    assert.ok(!isBragRequest(""));
+  });
+});
+
+// ── classifyToolUse ─────────────────────────────────────────────────────────
+
+describe("heuristics classifyToolUse", () => {
+  it("classifies file create tool", () => {
+    const result = classifyToolUse({
+      toolName: "create",
+      toolArgs: { path: "/repo/src/new.ts" },
+      toolResult: {},
+    });
+    assert.deepEqual(result.filesCreated, ["/repo/src/new.ts"]);
+    assert.deepEqual(result.filesEdited, []);
+    assert.deepEqual(result.prsCreated, []);
+    assert.deepEqual(result.significantActions, []);
+  });
+
+  it("classifies file edit tool", () => {
+    const result = classifyToolUse({
+      toolName: "edit",
+      toolArgs: { path: "/repo/src/main.ts" },
+      toolResult: {},
+    });
+    assert.deepEqual(result.filesEdited, ["/repo/src/main.ts"]);
+    assert.deepEqual(result.filesCreated, []);
+  });
+
+  it("classifies PR creation", () => {
+    const result = classifyToolUse({
+      toolName: "github-create_pull_request",
+      toolArgs: { title: "fix: bug", owner: "org", repo: "api" },
+      toolResult: { resultType: "success", textResultForLlm: '{"number": 7}' },
+    });
+    assert.equal(result.prsCreated.length, 1);
+    assert.equal(result.prsCreated[0].id, 7);
+    assert.equal(result.prsCreated[0].title, "fix: bug");
+    assert.ok(result.significantActions.includes("pr created"));
+  });
+
+  it("classifies github-push_files as git push action", () => {
+    const result = classifyToolUse({
+      toolName: "github-push_files",
+      toolArgs: {},
+      toolResult: {},
+    });
+    assert.ok(result.significantActions.includes("git push"));
+  });
+
+  it("classifies shell git commit", () => {
+    const result = classifyToolUse({
+      toolName: "powershell",
+      toolArgs: { command: 'git commit -m "fix"' },
+      toolResult: {},
+    });
+    assert.ok(result.significantActions.includes("git commit"));
+  });
+
+  it("classifies shell git push", () => {
+    const result = classifyToolUse({
+      toolName: "bash",
+      toolArgs: { command: "git push origin main" },
+      toolResult: {},
+    });
+    assert.ok(result.significantActions.includes("git push"));
+  });
+
+  it("returns empty classification for unrecognized tool", () => {
+    const result = classifyToolUse({
+      toolName: "grep",
+      toolArgs: { pattern: "foo" },
+      toolResult: {},
+    });
+    assert.deepEqual(result.filesCreated, []);
+    assert.deepEqual(result.filesEdited, []);
+    assert.deepEqual(result.prsCreated, []);
+    assert.deepEqual(result.significantActions, []);
+  });
+
+  it("returns empty classification for shell tool with non-git command", () => {
+    const result = classifyToolUse({
+      toolName: "bash",
+      toolArgs: { command: "npm test" },
+      toolResult: {},
+    });
+    assert.deepEqual(result.significantActions, []);
+  });
+
+  it("handles missing toolArgs gracefully", () => {
+    const result = classifyToolUse({
+      toolName: "create",
+      toolArgs: null,
+      toolResult: {},
+    });
+    assert.deepEqual(result.filesCreated, []);
+  });
+
+  it("skips failed PR results", () => {
+    const result = classifyToolUse({
+      toolName: "github-create_pull_request",
+      toolArgs: { title: "fix" },
+      toolResult: { resultType: "failure" },
+    });
+    assert.deepEqual(result.prsCreated, []);
+    assert.deepEqual(result.significantActions, []);
+  });
+});

--- a/test/operations.test.mjs
+++ b/test/operations.test.mjs
@@ -1,0 +1,232 @@
+/**
+ * Tests for lib/operations.mjs — shared tool handler core logic.
+ *
+ * These test the unified "validate → create → persist → backup" operations
+ * that both extension.mjs and mcp-server.mjs delegate to. Uses real disk
+ * I/O with per-test temp dirs for isolation.
+ */
+
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, readFileSync, existsSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import { ensureDir } from "../lib/paths.mjs";
+import { loadConfig } from "../lib/config.mjs";
+import { readRecords } from "../lib/storage.mjs";
+import {
+  saveBragEntry,
+  reviewBragEntries,
+  generateWorkLog,
+} from "../lib/operations.mjs";
+
+// ── Test fixtures ───────────────────────────────────────────────────────────
+
+let testDir;
+
+before(() => {
+  testDir = mkdtempSync(join(tmpdir(), "ops-test-"));
+});
+
+after(() => {
+  try { rmSync(testDir, { recursive: true, force: true }); } catch { /* noop */ }
+});
+
+function makeCtx(subdir) {
+  const dataDir = join(testDir, subdir);
+  ensureDir(dataDir);
+  const config = loadConfig(dataDir);
+  const gitConfig = { enabled: false, push: false };
+  return { dataDir, config, gitConfig };
+}
+
+// ── saveBragEntry ───────────────────────────────────────────────────────────
+
+describe("operations saveBragEntry", () => {
+  it("saves a valid entry and returns ok: true", () => {
+    const ctx = makeCtx("save-basic");
+    const result = saveBragEntry({
+      summary: "Fixed critical prod bug",
+      category: "bugfix",
+      impact: "Restored service for 1000 users",
+      tags: ["prod", "urgent"],
+      repo: "my-repo",
+      branch: "hotfix/123",
+      sessionId: "sess-123",
+    }, ctx);
+
+    assert.equal(result.ok, true);
+    assert.ok(result.entry);
+    assert.equal(result.entry.summary, "Fixed critical prod bug");
+    assert.equal(result.entry.category, "bugfix");
+    assert.ok(result.filePath);
+    assert.ok(existsSync(result.filePath));
+  });
+
+  it("persists to disk and is readable", () => {
+    const ctx = makeCtx("save-persist");
+    saveBragEntry({ summary: "Shipped feature X" }, ctx);
+
+    const records = readRecords(ctx.dataDir, { type: "entry" });
+    assert.equal(records.length, 1);
+    assert.equal(records[0].summary, "Shipped feature X");
+  });
+
+  it("returns ok: false for invalid category", () => {
+    const ctx = makeCtx("save-bad-cat");
+    const result = saveBragEntry({
+      summary: "Did work",
+      category: "nonexistent-category",
+    }, ctx);
+
+    assert.equal(result.ok, false);
+    assert.equal(result.code, "invalid_category");
+    assert.ok(result.message.includes("nonexistent-category"));
+    assert.ok(Array.isArray(result.validCategories));
+    assert.ok(result.validCategories.includes("pr"));
+  });
+
+  it("returns ok: false for empty summary", () => {
+    const ctx = makeCtx("save-empty");
+    const result = saveBragEntry({ summary: "" }, ctx);
+
+    assert.equal(result.ok, false);
+    assert.equal(result.code, "empty_summary");
+  });
+
+  it("returns ok: false for whitespace-only summary", () => {
+    const ctx = makeCtx("save-whitespace");
+    const result = saveBragEntry({ summary: "   " }, ctx);
+
+    assert.equal(result.ok, false);
+    assert.equal(result.code, "empty_summary");
+  });
+
+  it("returns ok: false for newline/tab-only summary", () => {
+    const ctx = makeCtx("save-tabs");
+    const result = saveBragEntry({ summary: "\n\t" }, ctx);
+
+    assert.equal(result.ok, false);
+    assert.equal(result.code, "empty_summary");
+  });
+
+  it("saves without category (null)", () => {
+    const ctx = makeCtx("save-no-cat");
+    const result = saveBragEntry({ summary: "Generic work" }, ctx);
+
+    assert.equal(result.ok, true);
+    assert.equal(result.entry.category, null);
+  });
+
+  it("saves with tags array", () => {
+    const ctx = makeCtx("save-tags");
+    const result = saveBragEntry({
+      summary: "Work with tags",
+      tags: ["perf", "ci"],
+    }, ctx);
+
+    assert.equal(result.ok, true);
+    assert.deepEqual(result.entry.tags, ["perf", "ci"]);
+  });
+
+  it("sanitizes summary text", () => {
+    const ctx = makeCtx("save-sanitize");
+    const result = saveBragEntry({
+      summary: "Fixed bug\nwith newline | and pipe",
+    }, ctx);
+
+    assert.equal(result.ok, true);
+    assert.ok(!result.entry.summary.includes("\n"));
+  });
+});
+
+// ── reviewBragEntries ───────────────────────────────────────────────────────
+
+describe("operations reviewBragEntries", () => {
+  it("returns records and metadata", () => {
+    const ctx = makeCtx("review-basic");
+    saveBragEntry({ summary: "Entry 1", category: "pr" }, ctx);
+    saveBragEntry({ summary: "Entry 2", category: "bugfix" }, ctx);
+
+    const result = reviewBragEntries({ weeks: 4 }, ctx);
+
+    assert.equal(result.ok, true);
+    assert.equal(result.records.length, 2);
+    assert.equal(result.weeks, 4);
+    assert.ok(result.markdown);
+    assert.ok(result.markdown.includes("Entry 1"));
+  });
+
+  it("returns empty results for no records", () => {
+    const ctx = makeCtx("review-empty");
+    ensureDir(join(ctx.dataDir, "entries"));
+
+    const result = reviewBragEntries({ weeks: 4 }, ctx);
+
+    assert.equal(result.ok, true);
+    assert.equal(result.records.length, 0);
+    assert.ok(typeof result.markdown === "string");
+  });
+
+  it("defaults to 4 weeks", () => {
+    const ctx = makeCtx("review-default");
+    const result = reviewBragEntries({}, ctx);
+
+    assert.equal(result.ok, true);
+    assert.equal(result.weeks, 4);
+  });
+
+  it("respects weeks parameter for filtering", () => {
+    const ctx = makeCtx("review-filter");
+    // Create an entry (it will be recent)
+    saveBragEntry({ summary: "Recent entry" }, ctx);
+
+    const result = reviewBragEntries({ weeks: 1 }, ctx);
+    assert.equal(result.ok, true);
+    assert.equal(result.records.length, 1);
+  });
+});
+
+// ── generateWorkLog ─────────────────────────────────────────────────────────
+
+describe("operations generateWorkLog", () => {
+  it("generates markdown file and returns metadata", () => {
+    const ctx = makeCtx("gen-basic");
+    saveBragEntry({ summary: "Built deployment pipeline", category: "infrastructure" }, ctx);
+
+    const outputPath = join(ctx.dataDir, "work-log.md");
+    const result = generateWorkLog({ outputPath }, ctx);
+
+    assert.equal(result.ok, true);
+    assert.equal(result.outputPath, outputPath);
+    assert.equal(result.recordCount, 1);
+    assert.ok(result.bytesWritten > 0);
+    assert.ok(existsSync(outputPath));
+
+    const content = readFileSync(outputPath, "utf8");
+    assert.ok(content.includes("Built deployment pipeline"));
+    assert.ok(content.includes("WEEKLY_ENTRIES_START"));
+  });
+
+  it("uses default output path when omitted", () => {
+    const ctx = makeCtx("gen-default");
+    saveBragEntry({ summary: "Some work" }, ctx);
+
+    const result = generateWorkLog({}, ctx);
+
+    assert.equal(result.ok, true);
+    assert.ok(result.outputPath.endsWith("work-log.md"));
+    assert.ok(existsSync(result.outputPath));
+  });
+
+  it("handles zero records gracefully", () => {
+    const ctx = makeCtx("gen-empty");
+    const outputPath = join(ctx.dataDir, "work-log.md");
+    const result = generateWorkLog({ outputPath }, ctx);
+
+    assert.equal(result.ok, true);
+    assert.equal(result.recordCount, 0);
+    assert.ok(existsSync(outputPath));
+  });
+});

--- a/test/storage.test.mjs
+++ b/test/storage.test.mjs
@@ -12,6 +12,7 @@ import { join, dirname } from "node:path";
 import { tmpdir } from "node:os";
 import {
   atomicWriteJSON,
+  atomicWriteText,
   writeRecord,
   readRecords,
   updateRecord,
@@ -268,4 +269,29 @@ test("readRecords ignores files outside the requested shard range", () => {
     }).map((record) => record.id),
     ["match"],
   );
+});
+
+test("atomicWriteText writes correct content and cleans temporary files", () => {
+  const tempDir = makeTempDir();
+  const filePath = join(tempDir, "test-output.md");
+
+  atomicWriteText(filePath, "# Hello\n\nSome markdown content.");
+
+  assert.ok(existsSync(filePath));
+  assert.equal(readFileSync(filePath, "utf8"), "# Hello\n\nSome markdown content.");
+
+  // No stale tmp file left behind
+  const files = readdirSync(tempDir);
+  assert.ok(!files.some(f => f.includes(".tmp.")));
+});
+
+test("atomicWriteText overwrites existing file atomically", () => {
+  const tempDir = makeTempDir();
+  const filePath = join(tempDir, "overwrite.md");
+
+  atomicWriteText(filePath, "version 1");
+  assert.equal(readFileSync(filePath, "utf8"), "version 1");
+
+  atomicWriteText(filePath, "version 2");
+  assert.equal(readFileSync(filePath, "utf8"), "version 2");
 });


### PR DESCRIPTION
# Phase 0: Extract shared lib modules

## Problem

`extension.mjs` and `mcp-server.mjs` duplicate tool classification logic, brag-entry orchestration, and `atomicWriteText`. Adding Agency hooks (Phase 1) would triplicate this.

## Solution

Extract shared logic into two new dependency-free `lib/` modules:

- **`lib/heuristics.mjs`** - Tool classification sets, extraction helpers, `isBragRequest`, composite `classifyToolUse()`
- **`lib/operations.mjs`** - Shared `saveBragEntry`/`reviewBragEntries`/`generateWorkLog` with `{ ok: true/false }` returns
- **`atomicWriteText`** moved from both entry points into `lib/storage.mjs`

## Test results

**177 tests, 0 failures** (was 127). Three-model adversarial council review passed.

## Bug fixes included

- `isBragRequest` false negatives on mixed prompts (caught by skeptic review)
- git config fallback NPE risk in extension.mjs (caught by architect review)

Partial progress on #22.
